### PR TITLE
Adding MASK filter strategy

### DIFF
--- a/phileas-model/src/main/java/ai/philterd/phileas/model/policy/filters/strategies/AbstractFilterStrategy.java
+++ b/phileas-model/src/main/java/ai/philterd/phileas/model/policy/filters/strategies/AbstractFilterStrategy.java
@@ -42,6 +42,7 @@ public abstract class AbstractFilterStrategy {
     public static final String FPE_ENCRYPT_REPLACE = "FPE_ENCRYPT_REPLACE";
     public static final String HASH_SHA256_REPLACE = "HASH_SHA256_REPLACE";
     public static final String LAST_4 = "LAST_4";
+    public static final String MASK = "MASK";
 
     // NER Person's name strategies
     public static final String ABBREVIATE = "ABBREVIATE";
@@ -96,6 +97,14 @@ public abstract class AbstractFilterStrategy {
     @SerializedName("staticReplacement")
     @Expose
     protected String staticReplacement = "";
+
+    @SerializedName("maskCharacter")
+    @Expose
+    protected String maskCharacter = "*";
+
+    @SerializedName("maskLength")
+    @Expose
+    protected String maskLength = "same";
 
     @SerializedName("condition")
     @Expose
@@ -337,6 +346,22 @@ public abstract class AbstractFilterStrategy {
 
     public void setStaticReplacement(String staticReplacement) {
         this.staticReplacement = staticReplacement;
+    }
+
+    public void setMaskCharacter(String maskCharacter) {
+        this.maskCharacter = maskCharacter;
+    }
+
+    public String getMaskCharacter() {
+        return maskCharacter;
+    }
+
+    public void setMaskLength(String maskLength) {
+        this.maskLength = maskLength;
+    }
+
+    public String getMaskLength() {
+        return maskLength;
     }
 
     public void setConditions(String condition) {

--- a/phileas-model/src/main/java/ai/philterd/phileas/model/policy/filters/strategies/ai/PersonsFilterStrategy.java
+++ b/phileas-model/src/main/java/ai/philterd/phileas/model/policy/filters/strategies/ai/PersonsFilterStrategy.java
@@ -142,6 +142,16 @@ public class PersonsFilterStrategy extends AbstractFilterStrategy {
 
             replacement = getRedactedToken(token, label, filterType);
 
+        } else if(StringUtils.equalsIgnoreCase(strategy, MASK)) {
+
+            int characters = token.length();
+
+            if(!StringUtils.equalsIgnoreCase(maskLength, "same")) {
+                characters = Integer.parseInt(maskLength);
+            }
+
+            replacement = maskCharacter.repeat(characters);
+
         } else if(StringUtils.equalsIgnoreCase(strategy, RANDOM_REPLACE)) {
 
             // Default to document scope.

--- a/phileas-model/src/main/java/ai/philterd/phileas/model/policy/filters/strategies/ai/PersonsFilterStrategy.java
+++ b/phileas-model/src/main/java/ai/philterd/phileas/model/policy/filters/strategies/ai/PersonsFilterStrategy.java
@@ -150,6 +150,10 @@ public class PersonsFilterStrategy extends AbstractFilterStrategy {
                 characters = Integer.parseInt(maskLength);
             }
 
+            if(characters < 1) {
+                characters = 5;
+            }
+
             replacement = maskCharacter.repeat(characters);
 
         } else if(StringUtils.equalsIgnoreCase(strategy, RANDOM_REPLACE)) {

--- a/phileas-model/src/main/java/ai/philterd/phileas/model/policy/filters/strategies/custom/CustomDictionaryFilterStrategy.java
+++ b/phileas-model/src/main/java/ai/philterd/phileas/model/policy/filters/strategies/custom/CustomDictionaryFilterStrategy.java
@@ -131,6 +131,16 @@ public class CustomDictionaryFilterStrategy extends AbstractFilterStrategy {
 
             replacement = getRedactedToken(token, label, filterType);
 
+        } else if(StringUtils.equalsIgnoreCase(strategy, MASK)) {
+
+            int characters = token.length();
+
+            if(!StringUtils.equalsIgnoreCase(maskLength, "same")) {
+                characters = Integer.parseInt(maskLength);
+            }
+
+            replacement = maskCharacter.repeat(characters);
+
         } else if(StringUtils.equalsIgnoreCase(strategy, RANDOM_REPLACE)) {
 
             // Default to document scope.

--- a/phileas-model/src/main/java/ai/philterd/phileas/model/policy/filters/strategies/custom/CustomDictionaryFilterStrategy.java
+++ b/phileas-model/src/main/java/ai/philterd/phileas/model/policy/filters/strategies/custom/CustomDictionaryFilterStrategy.java
@@ -139,6 +139,10 @@ public class CustomDictionaryFilterStrategy extends AbstractFilterStrategy {
                 characters = Integer.parseInt(maskLength);
             }
 
+            if(characters < 1) {
+                characters = 5;
+            }
+
             replacement = maskCharacter.repeat(characters);
 
         } else if(StringUtils.equalsIgnoreCase(strategy, RANDOM_REPLACE)) {

--- a/phileas-model/src/main/java/ai/philterd/phileas/model/policy/filters/strategies/dynamic/CityFilterStrategy.java
+++ b/phileas-model/src/main/java/ai/philterd/phileas/model/policy/filters/strategies/dynamic/CityFilterStrategy.java
@@ -128,6 +128,16 @@ public class CityFilterStrategy extends AbstractFilterStrategy {
 
             replacement = getRedactedToken(token, label, filterType);
 
+        } else if(StringUtils.equalsIgnoreCase(strategy, MASK)) {
+
+            int characters = token.length();
+
+            if(!StringUtils.equalsIgnoreCase(maskLength, "same")) {
+                characters = Integer.parseInt(maskLength);
+            }
+
+            replacement = maskCharacter.repeat(characters);
+
         } else if(StringUtils.equalsIgnoreCase(strategy, RANDOM_REPLACE)) {
 
             // Default to document scope.

--- a/phileas-model/src/main/java/ai/philterd/phileas/model/policy/filters/strategies/dynamic/CityFilterStrategy.java
+++ b/phileas-model/src/main/java/ai/philterd/phileas/model/policy/filters/strategies/dynamic/CityFilterStrategy.java
@@ -136,6 +136,10 @@ public class CityFilterStrategy extends AbstractFilterStrategy {
                 characters = Integer.parseInt(maskLength);
             }
 
+            if(characters < 1) {
+                characters = 5;
+            }
+
             replacement = maskCharacter.repeat(characters);
 
         } else if(StringUtils.equalsIgnoreCase(strategy, RANDOM_REPLACE)) {

--- a/phileas-model/src/main/java/ai/philterd/phileas/model/policy/filters/strategies/dynamic/CountyFilterStrategy.java
+++ b/phileas-model/src/main/java/ai/philterd/phileas/model/policy/filters/strategies/dynamic/CountyFilterStrategy.java
@@ -136,6 +136,10 @@ public class CountyFilterStrategy extends AbstractFilterStrategy {
                 characters = Integer.parseInt(maskLength);
             }
 
+            if(characters < 1) {
+                characters = 5;
+            }
+
             replacement = maskCharacter.repeat(characters);
 
         } else if(StringUtils.equalsIgnoreCase(strategy, RANDOM_REPLACE)) {

--- a/phileas-model/src/main/java/ai/philterd/phileas/model/policy/filters/strategies/dynamic/CountyFilterStrategy.java
+++ b/phileas-model/src/main/java/ai/philterd/phileas/model/policy/filters/strategies/dynamic/CountyFilterStrategy.java
@@ -128,6 +128,16 @@ public class CountyFilterStrategy extends AbstractFilterStrategy {
 
             replacement = getRedactedToken(token, label, filterType);
 
+        } else if(StringUtils.equalsIgnoreCase(strategy, MASK)) {
+
+            int characters = token.length();
+
+            if(!StringUtils.equalsIgnoreCase(maskLength, "same")) {
+                characters = Integer.parseInt(maskLength);
+            }
+
+            replacement = maskCharacter.repeat(characters);
+
         } else if(StringUtils.equalsIgnoreCase(strategy, RANDOM_REPLACE)) {
 
             // Default to document scope.

--- a/phileas-model/src/main/java/ai/philterd/phileas/model/policy/filters/strategies/dynamic/FirstNameFilterStrategy.java
+++ b/phileas-model/src/main/java/ai/philterd/phileas/model/policy/filters/strategies/dynamic/FirstNameFilterStrategy.java
@@ -128,6 +128,16 @@ public class FirstNameFilterStrategy extends AbstractFilterStrategy {
 
             replacement = getRedactedToken(token, label, filterType);
 
+        } else if(StringUtils.equalsIgnoreCase(strategy, MASK)) {
+
+            int characters = token.length();
+
+            if(!StringUtils.equalsIgnoreCase(maskLength, "same")) {
+                characters = Integer.parseInt(maskLength);
+            }
+
+            replacement = maskCharacter.repeat(characters);
+
         } else if(StringUtils.equalsIgnoreCase(strategy, RANDOM_REPLACE)) {
 
             // Default to document scope.

--- a/phileas-model/src/main/java/ai/philterd/phileas/model/policy/filters/strategies/dynamic/FirstNameFilterStrategy.java
+++ b/phileas-model/src/main/java/ai/philterd/phileas/model/policy/filters/strategies/dynamic/FirstNameFilterStrategy.java
@@ -136,6 +136,10 @@ public class FirstNameFilterStrategy extends AbstractFilterStrategy {
                 characters = Integer.parseInt(maskLength);
             }
 
+            if(characters < 1) {
+                characters = 5;
+            }
+
             replacement = maskCharacter.repeat(characters);
 
         } else if(StringUtils.equalsIgnoreCase(strategy, RANDOM_REPLACE)) {

--- a/phileas-model/src/main/java/ai/philterd/phileas/model/policy/filters/strategies/dynamic/HospitalAbbreviationFilterStrategy.java
+++ b/phileas-model/src/main/java/ai/philterd/phileas/model/policy/filters/strategies/dynamic/HospitalAbbreviationFilterStrategy.java
@@ -128,6 +128,16 @@ public class HospitalAbbreviationFilterStrategy extends AbstractFilterStrategy {
 
             replacement = getRedactedToken(token, label, filterType);
 
+        } else if(StringUtils.equalsIgnoreCase(strategy, MASK)) {
+
+            int characters = token.length();
+
+            if(!StringUtils.equalsIgnoreCase(maskLength, "same")) {
+                characters = Integer.parseInt(maskLength);
+            }
+
+            replacement = maskCharacter.repeat(characters);
+
         } else if(StringUtils.equalsIgnoreCase(strategy, RANDOM_REPLACE)) {
 
             // Default to document scope.

--- a/phileas-model/src/main/java/ai/philterd/phileas/model/policy/filters/strategies/dynamic/HospitalAbbreviationFilterStrategy.java
+++ b/phileas-model/src/main/java/ai/philterd/phileas/model/policy/filters/strategies/dynamic/HospitalAbbreviationFilterStrategy.java
@@ -136,6 +136,10 @@ public class HospitalAbbreviationFilterStrategy extends AbstractFilterStrategy {
                 characters = Integer.parseInt(maskLength);
             }
 
+            if(characters < 1) {
+                characters = 5;
+            }
+
             replacement = maskCharacter.repeat(characters);
 
         } else if(StringUtils.equalsIgnoreCase(strategy, RANDOM_REPLACE)) {

--- a/phileas-model/src/main/java/ai/philterd/phileas/model/policy/filters/strategies/dynamic/HospitalFilterStrategy.java
+++ b/phileas-model/src/main/java/ai/philterd/phileas/model/policy/filters/strategies/dynamic/HospitalFilterStrategy.java
@@ -136,6 +136,10 @@ public class HospitalFilterStrategy extends AbstractFilterStrategy {
                 characters = Integer.parseInt(maskLength);
             }
 
+            if(characters < 1) {
+                characters = 5;
+            }
+
             replacement = maskCharacter.repeat(characters);
 
         } else if(StringUtils.equalsIgnoreCase(strategy, RANDOM_REPLACE)) {

--- a/phileas-model/src/main/java/ai/philterd/phileas/model/policy/filters/strategies/dynamic/HospitalFilterStrategy.java
+++ b/phileas-model/src/main/java/ai/philterd/phileas/model/policy/filters/strategies/dynamic/HospitalFilterStrategy.java
@@ -128,6 +128,16 @@ public class HospitalFilterStrategy extends AbstractFilterStrategy {
 
             replacement = getRedactedToken(token, label, filterType);
 
+        } else if(StringUtils.equalsIgnoreCase(strategy, MASK)) {
+
+            int characters = token.length();
+
+            if(!StringUtils.equalsIgnoreCase(maskLength, "same")) {
+                characters = Integer.parseInt(maskLength);
+            }
+
+            replacement = maskCharacter.repeat(characters);
+
         } else if(StringUtils.equalsIgnoreCase(strategy, RANDOM_REPLACE)) {
 
             // Default to document scope.

--- a/phileas-model/src/main/java/ai/philterd/phileas/model/policy/filters/strategies/dynamic/StateFilterStrategy.java
+++ b/phileas-model/src/main/java/ai/philterd/phileas/model/policy/filters/strategies/dynamic/StateFilterStrategy.java
@@ -136,6 +136,10 @@ public class StateFilterStrategy extends AbstractFilterStrategy {
                 characters = Integer.parseInt(maskLength);
             }
 
+            if(characters < 1) {
+                characters = 5;
+            }
+
             replacement = maskCharacter.repeat(characters);
 
         } else if(StringUtils.equalsIgnoreCase(strategy, RANDOM_REPLACE)) {

--- a/phileas-model/src/main/java/ai/philterd/phileas/model/policy/filters/strategies/dynamic/StateFilterStrategy.java
+++ b/phileas-model/src/main/java/ai/philterd/phileas/model/policy/filters/strategies/dynamic/StateFilterStrategy.java
@@ -128,6 +128,16 @@ public class StateFilterStrategy extends AbstractFilterStrategy {
 
             replacement = getRedactedToken(token, label, filterType);
 
+        } else if(StringUtils.equalsIgnoreCase(strategy, MASK)) {
+
+            int characters = token.length();
+
+            if(!StringUtils.equalsIgnoreCase(maskLength, "same")) {
+                characters = Integer.parseInt(maskLength);
+            }
+
+            replacement = maskCharacter.repeat(characters);
+
         } else if(StringUtils.equalsIgnoreCase(strategy, RANDOM_REPLACE)) {
 
             // Default to document scope.

--- a/phileas-model/src/main/java/ai/philterd/phileas/model/policy/filters/strategies/dynamic/SurnameFilterStrategy.java
+++ b/phileas-model/src/main/java/ai/philterd/phileas/model/policy/filters/strategies/dynamic/SurnameFilterStrategy.java
@@ -137,7 +137,7 @@ public class SurnameFilterStrategy extends AbstractFilterStrategy {
             }
 
             replacement = maskCharacter.repeat(characters);
-            
+
         } else if(StringUtils.equalsIgnoreCase(strategy, RANDOM_REPLACE)) {
 
             // Default to document scope.

--- a/phileas-model/src/main/java/ai/philterd/phileas/model/policy/filters/strategies/dynamic/SurnameFilterStrategy.java
+++ b/phileas-model/src/main/java/ai/philterd/phileas/model/policy/filters/strategies/dynamic/SurnameFilterStrategy.java
@@ -128,6 +128,16 @@ public class SurnameFilterStrategy extends AbstractFilterStrategy {
 
             replacement = getRedactedToken(token, label, filterType);
 
+        } else if(StringUtils.equalsIgnoreCase(strategy, MASK)) {
+
+            int characters = token.length();
+
+            if(!StringUtils.equalsIgnoreCase(maskLength, "same")) {
+                characters = Integer.parseInt(maskLength);
+            }
+
+            replacement = maskCharacter.repeat(characters);
+            
         } else if(StringUtils.equalsIgnoreCase(strategy, RANDOM_REPLACE)) {
 
             // Default to document scope.

--- a/phileas-model/src/main/java/ai/philterd/phileas/model/policy/filters/strategies/dynamic/SurnameFilterStrategy.java
+++ b/phileas-model/src/main/java/ai/philterd/phileas/model/policy/filters/strategies/dynamic/SurnameFilterStrategy.java
@@ -136,6 +136,10 @@ public class SurnameFilterStrategy extends AbstractFilterStrategy {
                 characters = Integer.parseInt(maskLength);
             }
 
+            if(characters < 1) {
+                characters = 5;
+            }
+
             replacement = maskCharacter.repeat(characters);
 
         } else if(StringUtils.equalsIgnoreCase(strategy, RANDOM_REPLACE)) {

--- a/phileas-model/src/main/java/ai/philterd/phileas/model/policy/filters/strategies/rules/AgeFilterStrategy.java
+++ b/phileas-model/src/main/java/ai/philterd/phileas/model/policy/filters/strategies/rules/AgeFilterStrategy.java
@@ -140,6 +140,10 @@ public class AgeFilterStrategy extends AbstractFilterStrategy {
                 characters = Integer.parseInt(maskLength);
             }
 
+            if(characters < 1) {
+                characters = 5;
+            }
+
             replacement = maskCharacter.repeat(characters);
 
         } else if(StringUtils.equalsIgnoreCase(strategy, RANDOM_REPLACE)) {

--- a/phileas-model/src/main/java/ai/philterd/phileas/model/policy/filters/strategies/rules/AgeFilterStrategy.java
+++ b/phileas-model/src/main/java/ai/philterd/phileas/model/policy/filters/strategies/rules/AgeFilterStrategy.java
@@ -132,6 +132,16 @@ public class AgeFilterStrategy extends AbstractFilterStrategy {
 
             replacement = getRedactedToken(token, label, filterType);
 
+        } else if(StringUtils.equalsIgnoreCase(strategy, MASK)) {
+
+            int characters = token.length();
+
+            if(!StringUtils.equalsIgnoreCase(maskLength, "same")) {
+                characters = Integer.parseInt(maskLength);
+            }
+
+            replacement = maskCharacter.repeat(characters);
+
         } else if(StringUtils.equalsIgnoreCase(strategy, RANDOM_REPLACE)) {
 
             // Default to document scope.

--- a/phileas-model/src/main/java/ai/philterd/phileas/model/policy/filters/strategies/rules/BankRoutingNumberFilterStrategy.java
+++ b/phileas-model/src/main/java/ai/philterd/phileas/model/policy/filters/strategies/rules/BankRoutingNumberFilterStrategy.java
@@ -136,6 +136,10 @@ public class BankRoutingNumberFilterStrategy extends AbstractFilterStrategy {
                 characters = Integer.parseInt(maskLength);
             }
 
+            if(characters < 1) {
+                characters = 5;
+            }
+
             replacement = maskCharacter.repeat(characters);
 
         } else if(StringUtils.equalsIgnoreCase(strategy, RANDOM_REPLACE)) {

--- a/phileas-model/src/main/java/ai/philterd/phileas/model/policy/filters/strategies/rules/BankRoutingNumberFilterStrategy.java
+++ b/phileas-model/src/main/java/ai/philterd/phileas/model/policy/filters/strategies/rules/BankRoutingNumberFilterStrategy.java
@@ -128,6 +128,16 @@ public class BankRoutingNumberFilterStrategy extends AbstractFilterStrategy {
 
             replacement = getRedactedToken(token, label, filterType);
 
+        } else if(StringUtils.equalsIgnoreCase(strategy, MASK)) {
+
+            int characters = token.length();
+
+            if(!StringUtils.equalsIgnoreCase(maskLength, "same")) {
+                characters = Integer.parseInt(maskLength);
+            }
+
+            replacement = maskCharacter.repeat(characters);
+
         } else if(StringUtils.equalsIgnoreCase(strategy, RANDOM_REPLACE)) {
 
             // Default to document scope.

--- a/phileas-model/src/main/java/ai/philterd/phileas/model/policy/filters/strategies/rules/BitcoinAddressFilterStrategy.java
+++ b/phileas-model/src/main/java/ai/philterd/phileas/model/policy/filters/strategies/rules/BitcoinAddressFilterStrategy.java
@@ -127,6 +127,16 @@ public class BitcoinAddressFilterStrategy extends AbstractFilterStrategy {
 
             replacement = getRedactedToken(token, label, filterType);
 
+        } else if(StringUtils.equalsIgnoreCase(strategy, MASK)) {
+
+            int characters = token.length();
+
+            if(!StringUtils.equalsIgnoreCase(maskLength, "same")) {
+                characters = Integer.parseInt(maskLength);
+            }
+
+            replacement = maskCharacter.repeat(characters);
+
         } else if(StringUtils.equalsIgnoreCase(strategy, RANDOM_REPLACE)) {
 
             // Default to document scope.

--- a/phileas-model/src/main/java/ai/philterd/phileas/model/policy/filters/strategies/rules/BitcoinAddressFilterStrategy.java
+++ b/phileas-model/src/main/java/ai/philterd/phileas/model/policy/filters/strategies/rules/BitcoinAddressFilterStrategy.java
@@ -135,6 +135,10 @@ public class BitcoinAddressFilterStrategy extends AbstractFilterStrategy {
                 characters = Integer.parseInt(maskLength);
             }
 
+            if(characters < 1) {
+                characters = 5;
+            }
+
             replacement = maskCharacter.repeat(characters);
 
         } else if(StringUtils.equalsIgnoreCase(strategy, RANDOM_REPLACE)) {

--- a/phileas-model/src/main/java/ai/philterd/phileas/model/policy/filters/strategies/rules/CreditCardFilterStrategy.java
+++ b/phileas-model/src/main/java/ai/philterd/phileas/model/policy/filters/strategies/rules/CreditCardFilterStrategy.java
@@ -138,6 +138,10 @@ public class CreditCardFilterStrategy extends AbstractFilterStrategy {
                 characters = Integer.parseInt(maskLength);
             }
 
+            if(characters < 1) {
+                characters = 5;
+            }
+
             replacement = maskCharacter.repeat(characters);
 
         } else if(StringUtils.equalsIgnoreCase(strategy, RANDOM_REPLACE)) {

--- a/phileas-model/src/main/java/ai/philterd/phileas/model/policy/filters/strategies/rules/CreditCardFilterStrategy.java
+++ b/phileas-model/src/main/java/ai/philterd/phileas/model/policy/filters/strategies/rules/CreditCardFilterStrategy.java
@@ -130,6 +130,16 @@ public class CreditCardFilterStrategy extends AbstractFilterStrategy {
 
             replacement = getRedactedToken(token, label, filterType);
 
+        } else if(StringUtils.equalsIgnoreCase(strategy, MASK)) {
+
+            int characters = token.length();
+
+            if(!StringUtils.equalsIgnoreCase(maskLength, "same")) {
+                characters = Integer.parseInt(maskLength);
+            }
+
+            replacement = maskCharacter.repeat(characters);
+
         } else if(StringUtils.equalsIgnoreCase(strategy, RANDOM_REPLACE)) {
 
             // Default to document scope.

--- a/phileas-model/src/main/java/ai/philterd/phileas/model/policy/filters/strategies/rules/CurrencyFilterStrategy.java
+++ b/phileas-model/src/main/java/ai/philterd/phileas/model/policy/filters/strategies/rules/CurrencyFilterStrategy.java
@@ -128,6 +128,16 @@ public class CurrencyFilterStrategy extends AbstractFilterStrategy {
 
             replacement = getRedactedToken(token, label, filterType);
 
+        } else if(StringUtils.equalsIgnoreCase(strategy, MASK)) {
+
+            int characters = token.length();
+
+            if(!StringUtils.equalsIgnoreCase(maskLength, "same")) {
+                characters = Integer.parseInt(maskLength);
+            }
+
+            replacement = maskCharacter.repeat(characters);
+
         } else if(StringUtils.equalsIgnoreCase(strategy, RANDOM_REPLACE)) {
 
             // Default to document scope.

--- a/phileas-model/src/main/java/ai/philterd/phileas/model/policy/filters/strategies/rules/CurrencyFilterStrategy.java
+++ b/phileas-model/src/main/java/ai/philterd/phileas/model/policy/filters/strategies/rules/CurrencyFilterStrategy.java
@@ -136,6 +136,10 @@ public class CurrencyFilterStrategy extends AbstractFilterStrategy {
                 characters = Integer.parseInt(maskLength);
             }
 
+            if(characters < 1) {
+                characters = 5;
+            }
+
             replacement = maskCharacter.repeat(characters);
 
         } else if(StringUtils.equalsIgnoreCase(strategy, RANDOM_REPLACE)) {

--- a/phileas-model/src/main/java/ai/philterd/phileas/model/policy/filters/strategies/rules/DateFilterStrategy.java
+++ b/phileas-model/src/main/java/ai/philterd/phileas/model/policy/filters/strategies/rules/DateFilterStrategy.java
@@ -168,6 +168,10 @@ public class DateFilterStrategy extends AbstractFilterStrategy {
                 characters = Integer.parseInt(maskLength);
             }
 
+            if(characters < 1) {
+                characters = 5;
+            }
+
             replacement = maskCharacter.repeat(characters);
 
         } else if(StringUtils.equalsIgnoreCase(strategy, RANDOM_REPLACE)) {

--- a/phileas-model/src/main/java/ai/philterd/phileas/model/policy/filters/strategies/rules/DateFilterStrategy.java
+++ b/phileas-model/src/main/java/ai/philterd/phileas/model/policy/filters/strategies/rules/DateFilterStrategy.java
@@ -160,6 +160,16 @@ public class DateFilterStrategy extends AbstractFilterStrategy {
 
             replacement = getRedactedToken(token, label, filterType);
 
+        } else if(StringUtils.equalsIgnoreCase(strategy, MASK)) {
+
+            int characters = token.length();
+
+            if(!StringUtils.equalsIgnoreCase(maskLength, "same")) {
+                characters = Integer.parseInt(maskLength);
+            }
+
+            replacement = maskCharacter.repeat(characters);
+
         } else if(StringUtils.equalsIgnoreCase(strategy, RANDOM_REPLACE)) {
 
             // Default to document scope.

--- a/phileas-model/src/main/java/ai/philterd/phileas/model/policy/filters/strategies/rules/DriversLicenseFilterStrategy.java
+++ b/phileas-model/src/main/java/ai/philterd/phileas/model/policy/filters/strategies/rules/DriversLicenseFilterStrategy.java
@@ -138,6 +138,16 @@ public class DriversLicenseFilterStrategy extends AbstractFilterStrategy {
 
             replacement = getRedactedToken(token, label, filterType);
 
+        } else if(StringUtils.equalsIgnoreCase(strategy, MASK)) {
+
+            int characters = token.length();
+
+            if(!StringUtils.equalsIgnoreCase(maskLength, "same")) {
+                characters = Integer.parseInt(maskLength);
+            }
+
+            replacement = maskCharacter.repeat(characters);
+
         } else if(StringUtils.equalsIgnoreCase(strategy, RANDOM_REPLACE)) {
 
             // Default to document scope.

--- a/phileas-model/src/main/java/ai/philterd/phileas/model/policy/filters/strategies/rules/DriversLicenseFilterStrategy.java
+++ b/phileas-model/src/main/java/ai/philterd/phileas/model/policy/filters/strategies/rules/DriversLicenseFilterStrategy.java
@@ -146,6 +146,10 @@ public class DriversLicenseFilterStrategy extends AbstractFilterStrategy {
                 characters = Integer.parseInt(maskLength);
             }
 
+            if(characters < 1) {
+                characters = 5;
+            }
+
             replacement = maskCharacter.repeat(characters);
 
         } else if(StringUtils.equalsIgnoreCase(strategy, RANDOM_REPLACE)) {

--- a/phileas-model/src/main/java/ai/philterd/phileas/model/policy/filters/strategies/rules/EmailAddressFilterStrategy.java
+++ b/phileas-model/src/main/java/ai/philterd/phileas/model/policy/filters/strategies/rules/EmailAddressFilterStrategy.java
@@ -130,6 +130,16 @@ public class EmailAddressFilterStrategy extends AbstractFilterStrategy {
 
             replacement = getRedactedToken(token, label, filterType);
 
+        } else if(StringUtils.equalsIgnoreCase(strategy, MASK)) {
+
+            int characters = token.length();
+
+            if(!StringUtils.equalsIgnoreCase(maskLength, "same")) {
+                characters = Integer.parseInt(maskLength);
+            }
+
+            replacement = maskCharacter.repeat(characters);
+
         } else if(StringUtils.equalsIgnoreCase(strategy, RANDOM_REPLACE)) {
 
             // Default to document scope.

--- a/phileas-model/src/main/java/ai/philterd/phileas/model/policy/filters/strategies/rules/EmailAddressFilterStrategy.java
+++ b/phileas-model/src/main/java/ai/philterd/phileas/model/policy/filters/strategies/rules/EmailAddressFilterStrategy.java
@@ -138,6 +138,10 @@ public class EmailAddressFilterStrategy extends AbstractFilterStrategy {
                 characters = Integer.parseInt(maskLength);
             }
 
+            if(characters < 1) {
+                characters = 5;
+            }
+
             replacement = maskCharacter.repeat(characters);
 
         } else if(StringUtils.equalsIgnoreCase(strategy, RANDOM_REPLACE)) {

--- a/phileas-model/src/main/java/ai/philterd/phileas/model/policy/filters/strategies/rules/IbanCodeFilterStrategy.java
+++ b/phileas-model/src/main/java/ai/philterd/phileas/model/policy/filters/strategies/rules/IbanCodeFilterStrategy.java
@@ -128,6 +128,16 @@ public class IbanCodeFilterStrategy extends AbstractFilterStrategy {
 
             replacement = getRedactedToken(token, label, filterType);
 
+        } else if(StringUtils.equalsIgnoreCase(strategy, MASK)) {
+
+            int characters = token.length();
+
+            if(!StringUtils.equalsIgnoreCase(maskLength, "same")) {
+                characters = Integer.parseInt(maskLength);
+            }
+
+            replacement = maskCharacter.repeat(characters);
+
         } else if(StringUtils.equalsIgnoreCase(strategy, RANDOM_REPLACE)) {
 
             // Default to document scope.

--- a/phileas-model/src/main/java/ai/philterd/phileas/model/policy/filters/strategies/rules/IbanCodeFilterStrategy.java
+++ b/phileas-model/src/main/java/ai/philterd/phileas/model/policy/filters/strategies/rules/IbanCodeFilterStrategy.java
@@ -136,6 +136,10 @@ public class IbanCodeFilterStrategy extends AbstractFilterStrategy {
                 characters = Integer.parseInt(maskLength);
             }
 
+            if(characters < 1) {
+                characters = 5;
+            }
+
             replacement = maskCharacter.repeat(characters);
 
         } else if(StringUtils.equalsIgnoreCase(strategy, RANDOM_REPLACE)) {

--- a/phileas-model/src/main/java/ai/philterd/phileas/model/policy/filters/strategies/rules/IdentifierFilterStrategy.java
+++ b/phileas-model/src/main/java/ai/philterd/phileas/model/policy/filters/strategies/rules/IdentifierFilterStrategy.java
@@ -146,6 +146,10 @@ public class IdentifierFilterStrategy extends AbstractFilterStrategy {
                 characters = Integer.parseInt(maskLength);
             }
 
+            if(characters < 1) {
+                characters = 5;
+            }
+
             replacement = maskCharacter.repeat(characters);
 
         } else if(StringUtils.equalsIgnoreCase(strategy, RANDOM_REPLACE)) {

--- a/phileas-model/src/main/java/ai/philterd/phileas/model/policy/filters/strategies/rules/IdentifierFilterStrategy.java
+++ b/phileas-model/src/main/java/ai/philterd/phileas/model/policy/filters/strategies/rules/IdentifierFilterStrategy.java
@@ -138,6 +138,16 @@ public class IdentifierFilterStrategy extends AbstractFilterStrategy {
 
             replacement = getRedactedToken(token, label, filterType);
 
+        } else if(StringUtils.equalsIgnoreCase(strategy, MASK)) {
+
+            int characters = token.length();
+
+            if(!StringUtils.equalsIgnoreCase(maskLength, "same")) {
+                characters = Integer.parseInt(maskLength);
+            }
+
+            replacement = maskCharacter.repeat(characters);
+
         } else if(StringUtils.equalsIgnoreCase(strategy, RANDOM_REPLACE)) {
 
             // Default to document scope.

--- a/phileas-model/src/main/java/ai/philterd/phileas/model/policy/filters/strategies/rules/IpAddressFilterStrategy.java
+++ b/phileas-model/src/main/java/ai/philterd/phileas/model/policy/filters/strategies/rules/IpAddressFilterStrategy.java
@@ -136,6 +136,10 @@ public class IpAddressFilterStrategy extends AbstractFilterStrategy {
                 characters = Integer.parseInt(maskLength);
             }
 
+            if(characters < 1) {
+                characters = 5;
+            }
+
             replacement = maskCharacter.repeat(characters);
 
         } else if(StringUtils.equalsIgnoreCase(strategy, RANDOM_REPLACE)) {

--- a/phileas-model/src/main/java/ai/philterd/phileas/model/policy/filters/strategies/rules/IpAddressFilterStrategy.java
+++ b/phileas-model/src/main/java/ai/philterd/phileas/model/policy/filters/strategies/rules/IpAddressFilterStrategy.java
@@ -128,6 +128,16 @@ public class IpAddressFilterStrategy extends AbstractFilterStrategy {
 
             replacement = getRedactedToken(token, label, filterType);
 
+        } else if(StringUtils.equalsIgnoreCase(strategy, MASK)) {
+
+            int characters = token.length();
+
+            if(!StringUtils.equalsIgnoreCase(maskLength, "same")) {
+                characters = Integer.parseInt(maskLength);
+            }
+
+            replacement = maskCharacter.repeat(characters);
+
         } else if(StringUtils.equalsIgnoreCase(strategy, RANDOM_REPLACE)) {
 
             // Default to document scope.

--- a/phileas-model/src/main/java/ai/philterd/phileas/model/policy/filters/strategies/rules/MacAddressFilterStrategy.java
+++ b/phileas-model/src/main/java/ai/philterd/phileas/model/policy/filters/strategies/rules/MacAddressFilterStrategy.java
@@ -128,6 +128,16 @@ public class MacAddressFilterStrategy extends AbstractFilterStrategy {
 
             replacement = getRedactedToken(token, label, filterType);
 
+        } else if(StringUtils.equalsIgnoreCase(strategy, MASK)) {
+
+            int characters = token.length();
+
+            if(!StringUtils.equalsIgnoreCase(maskLength, "same")) {
+                characters = Integer.parseInt(maskLength);
+            }
+
+            replacement = maskCharacter.repeat(characters);
+
         } else if(StringUtils.equalsIgnoreCase(strategy, RANDOM_REPLACE)) {
 
             // Default to document scope.

--- a/phileas-model/src/main/java/ai/philterd/phileas/model/policy/filters/strategies/rules/MacAddressFilterStrategy.java
+++ b/phileas-model/src/main/java/ai/philterd/phileas/model/policy/filters/strategies/rules/MacAddressFilterStrategy.java
@@ -136,6 +136,10 @@ public class MacAddressFilterStrategy extends AbstractFilterStrategy {
                 characters = Integer.parseInt(maskLength);
             }
 
+            if(characters < 1) {
+                characters = 5;
+            }
+
             replacement = maskCharacter.repeat(characters);
 
         } else if(StringUtils.equalsIgnoreCase(strategy, RANDOM_REPLACE)) {

--- a/phileas-model/src/main/java/ai/philterd/phileas/model/policy/filters/strategies/rules/PassportNumberFilterStrategy.java
+++ b/phileas-model/src/main/java/ai/philterd/phileas/model/policy/filters/strategies/rules/PassportNumberFilterStrategy.java
@@ -138,6 +138,16 @@ public class PassportNumberFilterStrategy extends AbstractFilterStrategy {
 
             replacement = getRedactedToken(token, label, filterType);
 
+        } else if(StringUtils.equalsIgnoreCase(strategy, MASK)) {
+
+            int characters = token.length();
+
+            if(!StringUtils.equalsIgnoreCase(maskLength, "same")) {
+                characters = Integer.parseInt(maskLength);
+            }
+
+            replacement = maskCharacter.repeat(characters);
+
         } else if(StringUtils.equalsIgnoreCase(strategy, RANDOM_REPLACE)) {
 
             // Default to document scope.

--- a/phileas-model/src/main/java/ai/philterd/phileas/model/policy/filters/strategies/rules/PassportNumberFilterStrategy.java
+++ b/phileas-model/src/main/java/ai/philterd/phileas/model/policy/filters/strategies/rules/PassportNumberFilterStrategy.java
@@ -146,6 +146,10 @@ public class PassportNumberFilterStrategy extends AbstractFilterStrategy {
                 characters = Integer.parseInt(maskLength);
             }
 
+            if(characters < 1) {
+                characters = 5;
+            }
+
             replacement = maskCharacter.repeat(characters);
 
         } else if(StringUtils.equalsIgnoreCase(strategy, RANDOM_REPLACE)) {

--- a/phileas-model/src/main/java/ai/philterd/phileas/model/policy/filters/strategies/rules/PhoneNumberExtensionFilterStrategy.java
+++ b/phileas-model/src/main/java/ai/philterd/phileas/model/policy/filters/strategies/rules/PhoneNumberExtensionFilterStrategy.java
@@ -128,6 +128,16 @@ public class PhoneNumberExtensionFilterStrategy extends AbstractFilterStrategy {
 
             replacement = getRedactedToken(token, label, filterType);
 
+        } else if(StringUtils.equalsIgnoreCase(strategy, MASK)) {
+
+            int characters = token.length();
+
+            if(!StringUtils.equalsIgnoreCase(maskLength, "same")) {
+                characters = Integer.parseInt(maskLength);
+            }
+
+            replacement = maskCharacter.repeat(characters);
+
         } else if(StringUtils.equalsIgnoreCase(strategy, RANDOM_REPLACE)) {
 
             // Default to document scope.

--- a/phileas-model/src/main/java/ai/philterd/phileas/model/policy/filters/strategies/rules/PhoneNumberExtensionFilterStrategy.java
+++ b/phileas-model/src/main/java/ai/philterd/phileas/model/policy/filters/strategies/rules/PhoneNumberExtensionFilterStrategy.java
@@ -136,6 +136,10 @@ public class PhoneNumberExtensionFilterStrategy extends AbstractFilterStrategy {
                 characters = Integer.parseInt(maskLength);
             }
 
+            if(characters < 1) {
+                characters = 5;
+            }
+
             replacement = maskCharacter.repeat(characters);
 
         } else if(StringUtils.equalsIgnoreCase(strategy, RANDOM_REPLACE)) {

--- a/phileas-model/src/main/java/ai/philterd/phileas/model/policy/filters/strategies/rules/PhoneNumberFilterStrategy.java
+++ b/phileas-model/src/main/java/ai/philterd/phileas/model/policy/filters/strategies/rules/PhoneNumberFilterStrategy.java
@@ -136,6 +136,10 @@ public class PhoneNumberFilterStrategy extends AbstractFilterStrategy {
                 characters = Integer.parseInt(maskLength);
             }
 
+            if(characters < 1) {
+                characters = 5;
+            }
+
             replacement = maskCharacter.repeat(characters);
 
         } else if(StringUtils.equalsIgnoreCase(strategy, RANDOM_REPLACE)) {

--- a/phileas-model/src/main/java/ai/philterd/phileas/model/policy/filters/strategies/rules/PhoneNumberFilterStrategy.java
+++ b/phileas-model/src/main/java/ai/philterd/phileas/model/policy/filters/strategies/rules/PhoneNumberFilterStrategy.java
@@ -128,6 +128,16 @@ public class PhoneNumberFilterStrategy extends AbstractFilterStrategy {
 
             replacement = getRedactedToken(token, label, filterType);
 
+        } else if(StringUtils.equalsIgnoreCase(strategy, MASK)) {
+
+            int characters = token.length();
+
+            if(!StringUtils.equalsIgnoreCase(maskLength, "same")) {
+                characters = Integer.parseInt(maskLength);
+            }
+
+            replacement = maskCharacter.repeat(characters);
+
         } else if(StringUtils.equalsIgnoreCase(strategy, RANDOM_REPLACE)) {
 
             // Default to document scope.

--- a/phileas-model/src/main/java/ai/philterd/phileas/model/policy/filters/strategies/rules/PhysicianNameFilterStrategy.java
+++ b/phileas-model/src/main/java/ai/philterd/phileas/model/policy/filters/strategies/rules/PhysicianNameFilterStrategy.java
@@ -136,6 +136,10 @@ public class PhysicianNameFilterStrategy extends AbstractFilterStrategy {
                 characters = Integer.parseInt(maskLength);
             }
 
+            if(characters < 1) {
+                characters = 5;
+            }
+
             replacement = maskCharacter.repeat(characters);
 
         } else if(StringUtils.equalsIgnoreCase(strategy, RANDOM_REPLACE)) {

--- a/phileas-model/src/main/java/ai/philterd/phileas/model/policy/filters/strategies/rules/PhysicianNameFilterStrategy.java
+++ b/phileas-model/src/main/java/ai/philterd/phileas/model/policy/filters/strategies/rules/PhysicianNameFilterStrategy.java
@@ -128,6 +128,16 @@ public class PhysicianNameFilterStrategy extends AbstractFilterStrategy {
 
             replacement = getRedactedToken(token, label, filterType);
 
+        } else if(StringUtils.equalsIgnoreCase(strategy, MASK)) {
+
+            int characters = token.length();
+
+            if(!StringUtils.equalsIgnoreCase(maskLength, "same")) {
+                characters = Integer.parseInt(maskLength);
+            }
+
+            replacement = maskCharacter.repeat(characters);
+
         } else if(StringUtils.equalsIgnoreCase(strategy, RANDOM_REPLACE)) {
 
             // Default to document scope.

--- a/phileas-model/src/main/java/ai/philterd/phileas/model/policy/filters/strategies/rules/SectionFilterStrategy.java
+++ b/phileas-model/src/main/java/ai/philterd/phileas/model/policy/filters/strategies/rules/SectionFilterStrategy.java
@@ -136,6 +136,10 @@ public class SectionFilterStrategy extends AbstractFilterStrategy {
                 characters = Integer.parseInt(maskLength);
             }
 
+            if(characters < 1) {
+                characters = 5;
+            }
+
             replacement = maskCharacter.repeat(characters);
 
         } else if(StringUtils.equalsIgnoreCase(strategy, RANDOM_REPLACE)) {

--- a/phileas-model/src/main/java/ai/philterd/phileas/model/policy/filters/strategies/rules/SectionFilterStrategy.java
+++ b/phileas-model/src/main/java/ai/philterd/phileas/model/policy/filters/strategies/rules/SectionFilterStrategy.java
@@ -128,6 +128,16 @@ public class SectionFilterStrategy extends AbstractFilterStrategy {
 
             replacement = getRedactedToken(token, label, filterType);
 
+        } else if(StringUtils.equalsIgnoreCase(strategy, MASK)) {
+
+            int characters = token.length();
+
+            if(!StringUtils.equalsIgnoreCase(maskLength, "same")) {
+                characters = Integer.parseInt(maskLength);
+            }
+
+            replacement = maskCharacter.repeat(characters);
+
         } else if(StringUtils.equalsIgnoreCase(strategy, RANDOM_REPLACE)) {
 
             // Default to document scope.

--- a/phileas-model/src/main/java/ai/philterd/phileas/model/policy/filters/strategies/rules/SsnFilterStrategy.java
+++ b/phileas-model/src/main/java/ai/philterd/phileas/model/policy/filters/strategies/rules/SsnFilterStrategy.java
@@ -136,6 +136,10 @@ public class SsnFilterStrategy extends AbstractFilterStrategy {
                 characters = Integer.parseInt(maskLength);
             }
 
+            if(characters < 1) {
+                characters = 5;
+            }
+
             replacement = maskCharacter.repeat(characters);
 
         } else if(StringUtils.equalsIgnoreCase(strategy, RANDOM_REPLACE)) {

--- a/phileas-model/src/main/java/ai/philterd/phileas/model/policy/filters/strategies/rules/SsnFilterStrategy.java
+++ b/phileas-model/src/main/java/ai/philterd/phileas/model/policy/filters/strategies/rules/SsnFilterStrategy.java
@@ -128,6 +128,16 @@ public class SsnFilterStrategy extends AbstractFilterStrategy {
 
             replacement = getRedactedToken(token, label, filterType);
 
+        } else if(StringUtils.equalsIgnoreCase(strategy, MASK)) {
+
+            int characters = token.length();
+
+            if(!StringUtils.equalsIgnoreCase(maskLength, "same")) {
+                characters = Integer.parseInt(maskLength);
+            }
+
+            replacement = maskCharacter.repeat(characters);
+
         } else if(StringUtils.equalsIgnoreCase(strategy, RANDOM_REPLACE)) {
 
             // Default to document scope.

--- a/phileas-model/src/main/java/ai/philterd/phileas/model/policy/filters/strategies/rules/StateAbbreviationFilterStrategy.java
+++ b/phileas-model/src/main/java/ai/philterd/phileas/model/policy/filters/strategies/rules/StateAbbreviationFilterStrategy.java
@@ -136,6 +136,10 @@ public class StateAbbreviationFilterStrategy extends AbstractFilterStrategy {
                 characters = Integer.parseInt(maskLength);
             }
 
+            if(characters < 1) {
+                characters = 5;
+            }
+
             replacement = maskCharacter.repeat(characters);
 
         } else if(StringUtils.equalsIgnoreCase(strategy, RANDOM_REPLACE)) {

--- a/phileas-model/src/main/java/ai/philterd/phileas/model/policy/filters/strategies/rules/StateAbbreviationFilterStrategy.java
+++ b/phileas-model/src/main/java/ai/philterd/phileas/model/policy/filters/strategies/rules/StateAbbreviationFilterStrategy.java
@@ -128,6 +128,16 @@ public class StateAbbreviationFilterStrategy extends AbstractFilterStrategy {
 
             replacement = getRedactedToken(token, label, filterType);
 
+        } else if(StringUtils.equalsIgnoreCase(strategy, MASK)) {
+
+            int characters = token.length();
+
+            if(!StringUtils.equalsIgnoreCase(maskLength, "same")) {
+                characters = Integer.parseInt(maskLength);
+            }
+
+            replacement = maskCharacter.repeat(characters);
+
         } else if(StringUtils.equalsIgnoreCase(strategy, RANDOM_REPLACE)) {
 
             // Default to document scope.

--- a/phileas-model/src/main/java/ai/philterd/phileas/model/policy/filters/strategies/rules/StreetAddressFilterStrategy.java
+++ b/phileas-model/src/main/java/ai/philterd/phileas/model/policy/filters/strategies/rules/StreetAddressFilterStrategy.java
@@ -136,6 +136,10 @@ public class StreetAddressFilterStrategy extends AbstractFilterStrategy {
                 characters = Integer.parseInt(maskLength);
             }
 
+            if(characters < 1) {
+                characters = 5;
+            }
+
             replacement = maskCharacter.repeat(characters);
 
         } else if(StringUtils.equalsIgnoreCase(strategy, RANDOM_REPLACE)) {

--- a/phileas-model/src/main/java/ai/philterd/phileas/model/policy/filters/strategies/rules/StreetAddressFilterStrategy.java
+++ b/phileas-model/src/main/java/ai/philterd/phileas/model/policy/filters/strategies/rules/StreetAddressFilterStrategy.java
@@ -128,6 +128,16 @@ public class StreetAddressFilterStrategy extends AbstractFilterStrategy {
 
             replacement = getRedactedToken(token, label, filterType);
 
+        } else if(StringUtils.equalsIgnoreCase(strategy, MASK)) {
+
+            int characters = token.length();
+
+            if(!StringUtils.equalsIgnoreCase(maskLength, "same")) {
+                characters = Integer.parseInt(maskLength);
+            }
+
+            replacement = maskCharacter.repeat(characters);
+
         } else if(StringUtils.equalsIgnoreCase(strategy, RANDOM_REPLACE)) {
 
             // Default to document scope.

--- a/phileas-model/src/main/java/ai/philterd/phileas/model/policy/filters/strategies/rules/TrackingNumberFilterStrategy.java
+++ b/phileas-model/src/main/java/ai/philterd/phileas/model/policy/filters/strategies/rules/TrackingNumberFilterStrategy.java
@@ -136,6 +136,10 @@ public class TrackingNumberFilterStrategy extends AbstractFilterStrategy {
                 characters = Integer.parseInt(maskLength);
             }
 
+            if(characters < 1) {
+                characters = 5;
+            }
+
             replacement = maskCharacter.repeat(characters);
 
         } else if(StringUtils.equalsIgnoreCase(strategy, RANDOM_REPLACE)) {

--- a/phileas-model/src/main/java/ai/philterd/phileas/model/policy/filters/strategies/rules/TrackingNumberFilterStrategy.java
+++ b/phileas-model/src/main/java/ai/philterd/phileas/model/policy/filters/strategies/rules/TrackingNumberFilterStrategy.java
@@ -128,6 +128,16 @@ public class TrackingNumberFilterStrategy extends AbstractFilterStrategy {
 
             replacement = getRedactedToken(token, label, filterType);
 
+        } else if(StringUtils.equalsIgnoreCase(strategy, MASK)) {
+
+            int characters = token.length();
+
+            if(!StringUtils.equalsIgnoreCase(maskLength, "same")) {
+                characters = Integer.parseInt(maskLength);
+            }
+
+            replacement = maskCharacter.repeat(characters);
+
         } else if(StringUtils.equalsIgnoreCase(strategy, RANDOM_REPLACE)) {
 
             // Default to document scope.

--- a/phileas-model/src/main/java/ai/philterd/phileas/model/policy/filters/strategies/rules/UrlFilterStrategy.java
+++ b/phileas-model/src/main/java/ai/philterd/phileas/model/policy/filters/strategies/rules/UrlFilterStrategy.java
@@ -136,6 +136,10 @@ public class UrlFilterStrategy extends AbstractFilterStrategy {
                 characters = Integer.parseInt(maskLength);
             }
 
+            if(characters < 1) {
+                characters = 5;
+            }
+
             replacement = maskCharacter.repeat(characters);
 
         } else if(StringUtils.equalsIgnoreCase(strategy, RANDOM_REPLACE)) {

--- a/phileas-model/src/main/java/ai/philterd/phileas/model/policy/filters/strategies/rules/UrlFilterStrategy.java
+++ b/phileas-model/src/main/java/ai/philterd/phileas/model/policy/filters/strategies/rules/UrlFilterStrategy.java
@@ -128,6 +128,16 @@ public class UrlFilterStrategy extends AbstractFilterStrategy {
 
             replacement = getRedactedToken(token, label, filterType);
 
+        } else if(StringUtils.equalsIgnoreCase(strategy, MASK)) {
+
+            int characters = token.length();
+
+            if(!StringUtils.equalsIgnoreCase(maskLength, "same")) {
+                characters = Integer.parseInt(maskLength);
+            }
+
+            replacement = maskCharacter.repeat(characters);
+
         } else if(StringUtils.equalsIgnoreCase(strategy, RANDOM_REPLACE)) {
 
             // Default to document scope.

--- a/phileas-model/src/main/java/ai/philterd/phileas/model/policy/filters/strategies/rules/VinFilterStrategy.java
+++ b/phileas-model/src/main/java/ai/philterd/phileas/model/policy/filters/strategies/rules/VinFilterStrategy.java
@@ -136,6 +136,10 @@ public class VinFilterStrategy extends AbstractFilterStrategy {
                 characters = Integer.parseInt(maskLength);
             }
 
+            if(characters < 1) {
+                characters = 5;
+            }
+
             replacement = maskCharacter.repeat(characters);
 
         } else if(StringUtils.equalsIgnoreCase(strategy, RANDOM_REPLACE)) {

--- a/phileas-model/src/main/java/ai/philterd/phileas/model/policy/filters/strategies/rules/VinFilterStrategy.java
+++ b/phileas-model/src/main/java/ai/philterd/phileas/model/policy/filters/strategies/rules/VinFilterStrategy.java
@@ -128,6 +128,16 @@ public class VinFilterStrategy extends AbstractFilterStrategy {
 
             replacement = getRedactedToken(token, label, filterType);
 
+        } else if(StringUtils.equalsIgnoreCase(strategy, MASK)) {
+
+            int characters = token.length();
+
+            if(!StringUtils.equalsIgnoreCase(maskLength, "same")) {
+                characters = Integer.parseInt(maskLength);
+            }
+
+            replacement = maskCharacter.repeat(characters);
+
         } else if(StringUtils.equalsIgnoreCase(strategy, RANDOM_REPLACE)) {
 
             // Default to document scope.

--- a/phileas-model/src/main/java/ai/philterd/phileas/model/policy/filters/strategies/rules/ZipCodeFilterStrategy.java
+++ b/phileas-model/src/main/java/ai/philterd/phileas/model/policy/filters/strategies/rules/ZipCodeFilterStrategy.java
@@ -169,6 +169,16 @@ public class ZipCodeFilterStrategy extends AbstractFilterStrategy {
 
             replacement = getRedactedToken(token, label, filterType);
 
+        } else if(StringUtils.equalsIgnoreCase(strategy, MASK)) {
+
+            int characters = token.length();
+
+            if(!StringUtils.equalsIgnoreCase(maskLength, "same")) {
+                characters = Integer.parseInt(maskLength);
+            }
+
+            replacement = maskCharacter.repeat(characters);
+
         } else if(StringUtils.equalsIgnoreCase(strategy, RANDOM_REPLACE)) {
 
             // Default to document scope.

--- a/phileas-model/src/main/java/ai/philterd/phileas/model/policy/filters/strategies/rules/ZipCodeFilterStrategy.java
+++ b/phileas-model/src/main/java/ai/philterd/phileas/model/policy/filters/strategies/rules/ZipCodeFilterStrategy.java
@@ -177,6 +177,10 @@ public class ZipCodeFilterStrategy extends AbstractFilterStrategy {
                 characters = Integer.parseInt(maskLength);
             }
 
+            if(characters < 1) {
+                characters = 5;
+            }
+
             replacement = maskCharacter.repeat(characters);
 
         } else if(StringUtils.equalsIgnoreCase(strategy, RANDOM_REPLACE)) {

--- a/phileas-model/src/test/java/ai/philterd/test/phileas/model/policy/filters/strategies/AbstractFilterStrategyTest.java
+++ b/phileas-model/src/test/java/ai/philterd/test/phileas/model/policy/filters/strategies/AbstractFilterStrategyTest.java
@@ -272,6 +272,27 @@ public abstract class AbstractFilterStrategyTest {
     }
 
     @Test
+    public void replacementWithMaskCharacterForSetLengthWithNegativeLength() throws Exception {
+
+        final AnonymizationService anonymizationService = Mockito.mock(AnonymizationService.class);
+        final AnonymizationCacheService anonymizationCacheService = Mockito.mock(AnonymizationCacheService.class);
+
+        when(anonymizationService.getAnonymizationCacheService()).thenReturn(anonymizationCacheService);
+
+        final AbstractFilterStrategy strategy = getFilterStrategy();
+        strategy.setStrategy(AbstractFilterStrategy.MASK);
+        strategy.setMaskCharacter("#");
+        strategy.setMaskLength("0");
+
+        final String token = "token";
+        final Replacement replacement = strategy.getReplacement("name", "context", "docId", token, WINDOW, null, null, anonymizationService, null);
+
+        Assertions.assertEquals(replacement.getReplacement(), "#####");
+        Assertions.assertEquals(replacement.getReplacement().length(), 5);
+
+    }
+
+    @Test
     public void evaluateCondition1() throws IOException {
 
         final AbstractFilterStrategy strategy = getFilterStrategy();

--- a/phileas-model/src/test/java/ai/philterd/test/phileas/model/policy/filters/strategies/AbstractFilterStrategyTest.java
+++ b/phileas-model/src/test/java/ai/philterd/test/phileas/model/policy/filters/strategies/AbstractFilterStrategyTest.java
@@ -231,6 +231,25 @@ public abstract class AbstractFilterStrategyTest {
     }
 
     @Test
+    public void replacementWithMaskCharacter() throws Exception {
+
+        final AnonymizationService anonymizationService = Mockito.mock(AnonymizationService.class);
+        final AnonymizationCacheService anonymizationCacheService = Mockito.mock(AnonymizationCacheService.class);
+
+        when(anonymizationService.getAnonymizationCacheService()).thenReturn(anonymizationCacheService);
+
+        final AbstractFilterStrategy strategy = getFilterStrategy();
+        strategy.setStrategy(AbstractFilterStrategy.MASK);
+
+        final String token = "token";
+        final Replacement replacement = strategy.getReplacement("name", "context", "docId", token, WINDOW, null, null, anonymizationService, null);
+
+        Assertions.assertEquals(replacement.getReplacement(), "*****");
+        Assertions.assertEquals(replacement.getReplacement().length(), token.length());
+
+    }
+
+    @Test
     public void evaluateCondition1() throws IOException {
 
         final AbstractFilterStrategy strategy = getFilterStrategy();

--- a/phileas-model/src/test/java/ai/philterd/test/phileas/model/policy/filters/strategies/AbstractFilterStrategyTest.java
+++ b/phileas-model/src/test/java/ai/philterd/test/phileas/model/policy/filters/strategies/AbstractFilterStrategyTest.java
@@ -231,7 +231,7 @@ public abstract class AbstractFilterStrategyTest {
     }
 
     @Test
-    public void replacementWithMaskCharacter() throws Exception {
+    public void replacementWithMaskCharacterForSameLength() throws Exception {
 
         final AnonymizationService anonymizationService = Mockito.mock(AnonymizationService.class);
         final AnonymizationCacheService anonymizationCacheService = Mockito.mock(AnonymizationCacheService.class);
@@ -240,12 +240,34 @@ public abstract class AbstractFilterStrategyTest {
 
         final AbstractFilterStrategy strategy = getFilterStrategy();
         strategy.setStrategy(AbstractFilterStrategy.MASK);
+        strategy.setMaskLength("same");
 
         final String token = "token";
         final Replacement replacement = strategy.getReplacement("name", "context", "docId", token, WINDOW, null, null, anonymizationService, null);
 
         Assertions.assertEquals(replacement.getReplacement(), "*****");
         Assertions.assertEquals(replacement.getReplacement().length(), token.length());
+
+    }
+
+    @Test
+    public void replacementWithMaskCharacterForSetLength() throws Exception {
+
+        final AnonymizationService anonymizationService = Mockito.mock(AnonymizationService.class);
+        final AnonymizationCacheService anonymizationCacheService = Mockito.mock(AnonymizationCacheService.class);
+
+        when(anonymizationService.getAnonymizationCacheService()).thenReturn(anonymizationCacheService);
+
+        final AbstractFilterStrategy strategy = getFilterStrategy();
+        strategy.setStrategy(AbstractFilterStrategy.MASK);
+        strategy.setMaskCharacter("#");
+        strategy.setMaskLength("10");
+
+        final String token = "token";
+        final Replacement replacement = strategy.getReplacement("name", "context", "docId", token, WINDOW, null, null, anonymizationService, null);
+
+        Assertions.assertEquals(replacement.getReplacement(), "##########");
+        Assertions.assertEquals(replacement.getReplacement().length(), 10);
 
     }
 


### PR DESCRIPTION
With this filter, you can replace text with a given character of some arbitrary length or the same length. An example filter profile is:

```
{
   "name": "email-address",
   "identifiers": {
      "emailAddress": {
         "emailAddressFilterStrategies": [
            {
               "strategy": "MASK",
               "maskCharacter": "*",
               "maskLength": "same"
            }
         ]
      }
   }
}
```