### PR TITLE
Improved performance for email address detection

### DIFF
--- a/phileas-core/src/main/java/ai/philterd/phileas/services/FilterPolicyLoader.java
+++ b/phileas-core/src/main/java/ai/philterd/phileas/services/FilterPolicyLoader.java
@@ -293,7 +293,9 @@ public class FilterPolicyLoader {
                         .withWindowSize(phileasConfiguration.spanWindowSize())
                         .build();
 
-                final Filter filter = new EmailAddressFilter(filterConfiguration);
+                final boolean isStrict = policy.getIdentifiers().getEmailAddress().isOnlyStrictMatches();
+
+                final Filter filter = new EmailAddressFilter(filterConfiguration, isStrict);
                 enabledFilters.add(filter);
                 filterCache.get(policy.getName()).put(FilterType.EMAIL_ADDRESS, filter);
 

--- a/phileas-core/src/main/java/ai/philterd/phileas/services/filters/regex/EmailAddressFilter.java
+++ b/phileas-core/src/main/java/ai/philterd/phileas/services/filters/regex/EmailAddressFilter.java
@@ -31,10 +31,13 @@ import java.util.regex.Pattern;
 
 public class EmailAddressFilter extends RegexFilter {
 
-    public EmailAddressFilter(FilterConfiguration filterConfiguration) {
+    public EmailAddressFilter(FilterConfiguration filterConfiguration, boolean onlyStrictMatches) {
         super(FilterType.EMAIL_ADDRESS, filterConfiguration);
 
-        final Pattern emailAddressPattern = Pattern.compile("(?:[a-z0-9!#$%&'*+/=?^_`{|}~-]+(?:\\.[a-z0-9!#$%&'*+/=?^_`{|}~-]+)*|\"(?:[\\x01-\\x08\\x0b\\x0c\\x0e-\\x1f\\x21\\x23-\\x5b\\x5d-\\x7f]|\\\\[\\x01-\\x09\\x0b\\x0c\\x0e-\\x7f])*\")@(?:(?:[a-z0-9](?:[a-z0-9-]*[a-z0-9])?\\.)+[a-z0-9](?:[a-z0-9-]*[a-z0-9])?|\\[(?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\\.){3}(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?|[a-z0-9-]*[a-z0-9]:(?:[\\x01-\\x08\\x0b\\x0c\\x0e-\\x1f\\x21-\\x5a\\x53-\\x7f]|\\\\[\\x01-\\x09\\x0b\\x0c\\x0e-\\x7f])+)\\])", Pattern.CASE_INSENSITIVE);
+        final Pattern emailAddressPattern = onlyStrictMatches
+                ? Pattern.compile("\\b(?:[a-z0-9!#$%&'*+/=?^_`{|}~-]+(?:\\.[a-z0-9!#$%&'*+/=?^_`{|}~-]+)*|\"(?:[\\x01-\\x08\\x0b\\x0c\\x0e-\\x1f\\x21\\x23-\\x5b\\x5d-\\x7f]|\\\\[\\x01-\\x09\\x0b\\x0c\\x0e-\\x7f])*\")@(?:(?:[a-z0-9](?:[a-z0-9-]*[a-z0-9])?\\.)+[a-z0-9](?:[a-z0-9-]*[a-z0-9])?|\\[(?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\\.){3}(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?|[a-z0-9-]*[a-z0-9]:(?:[\\x01-\\x08\\x0b\\x0c\\x0e-\\x1f\\x21-\\x5a\\x53-\\x7f]|\\\\[\\x01-\\x09\\x0b\\x0c\\x0e-\\x7f])+)\\b])", Pattern.CASE_INSENSITIVE)
+                : Pattern.compile("\\b[\\w.-]+?@(?:([a-zA-Z\\d\\-])+?\\.)+(?:[a-zA-Z\\d]{2,4})+\\b");
+
         final FilterPattern email1 = new FilterPattern.FilterPatternBuilder(emailAddressPattern, 0.90).build();
 
         this.contextualTerms = new HashSet<>();

--- a/phileas-model/src/main/java/ai/philterd/phileas/model/policy/filters/EmailAddress.java
+++ b/phileas-model/src/main/java/ai/philterd/phileas/model/policy/filters/EmailAddress.java
@@ -23,6 +23,10 @@ import java.util.List;
 
 public class EmailAddress extends AbstractFilter {
 
+    @SerializedName("onlyStrictMatches")
+    @Expose
+    protected boolean onlyStrictMatches = true;
+
     @SerializedName("emailAddressFilterStrategies")
     @Expose
     private List<EmailAddressFilterStrategy> emailAddressFilterStrategies;
@@ -33,6 +37,14 @@ public class EmailAddress extends AbstractFilter {
 
     public void setEmailAddressFilterStrategies(List<EmailAddressFilterStrategy> emailAddressFilterStrategies) {
         this.emailAddressFilterStrategies = emailAddressFilterStrategies;
+    }
+
+    public boolean isOnlyStrictMatches() {
+        return onlyStrictMatches;
+    }
+
+    public void setOnlyStrictMatches(boolean value) {
+        onlyStrictMatches = value;
     }
 
 }


### PR DESCRIPTION
Changes related to #121 

* Introduces `EmailAddress.onlyStrictMatches` (true by default, uses original regex)
* Uses simplified regular expression when `EmailAddress.onlyStrictMatches = false`
* Email address detection is 2x faster than before (`\b...\b` fencing around the regex)
* With `EmailAddress.onlyStrictMatches = false`, email address detection is 4x faster than before
* Expanded test cases to cover variations not exercised before

There's only three identified cases where there are matching differences between strict and relaxed modes, but this is worth the large difference in performance.

Phileas also uses less stack as a result of these changes -- with the previous implementation, I was seeing a lot of StackOverflowErrors with large strings even when configuring a larger stack size than default.