### PR TITLE
Removing commons-csv dependency

### DIFF
--- a/phileas-model/pom.xml
+++ b/phileas-model/pom.xml
@@ -91,11 +91,6 @@
 			<version>${commons.math.version}</version>
 		</dependency>
 		<dependency>
-			<groupId>org.apache.commons</groupId>
-			<artifactId>commons-csv</artifactId>
-			<version>${commons.csv.version}</version>
-		</dependency>
-		<dependency>
 			<groupId>commons-codec</groupId>
 			<artifactId>commons-codec</artifactId>
 			<version>${commons.codec.version}</version>

--- a/phileas-model/src/main/java/ai/philterd/phileas/model/metadata/zipcode/ZipCodeMetadataService.java
+++ b/phileas-model/src/main/java/ai/philterd/phileas/model/metadata/zipcode/ZipCodeMetadataService.java
@@ -16,14 +16,11 @@
 package ai.philterd.phileas.model.metadata.zipcode;
 
 import ai.philterd.phileas.model.metadata.MetadataService;
-import org.apache.commons.csv.CSVFormat;
-import org.apache.commons.csv.CSVParser;
-import org.apache.commons.csv.CSVRecord;
 
+import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
-import java.io.Reader;
 import java.util.HashMap;
 
 public class ZipCodeMetadataService implements MetadataService<ZipCodeMetadataRequest, ZipCodeMetadataResponse> {
@@ -47,21 +44,24 @@ public class ZipCodeMetadataService implements MetadataService<ZipCodeMetadataRe
 
         final HashMap<String, Integer> zipcodes = new HashMap<>();
 
-        final InputStream inputStream = getClass().getClassLoader().getResourceAsStream("2010+Census+Population+By+Zipcode.csv");
+        try (InputStream inputStream =  getClass().getClassLoader().getResourceAsStream("2010+Census+Population+By+Zipcode.csv");
+             InputStreamReader inputStreamReader = new InputStreamReader(inputStream)) {
 
-        final Reader reader = new InputStreamReader(inputStream);
-        final CSVParser csvParser = new CSVParser(reader, CSVFormat.DEFAULT);
+            final BufferedReader bufferedReader = new BufferedReader(inputStreamReader);
 
-        for (final CSVRecord csvRecord : csvParser) {
+            String line;
+            while ((line = bufferedReader.readLine()) != null) {
 
-            final String zipCode = csvRecord.get(0);
-            final int population = Integer.parseInt(csvRecord.get(1));
+                final String[] zipCodePopulation = line.split(",");
 
-            zipcodes.put(zipCode, population);
+                final String zipCode = zipCodePopulation[0];
+                final int population = Integer.parseInt(zipCodePopulation[1]);
+
+                zipcodes.put(zipCode, population);
+
+            }
 
         }
-
-        reader.close();
 
         return zipcodes;
 

--- a/phileas-model/src/test/java/ai/philterd/test/phileas/model/metadata/zipcode/ZipCodeMetadataServiceTest.java
+++ b/phileas-model/src/test/java/ai/philterd/test/phileas/model/metadata/zipcode/ZipCodeMetadataServiceTest.java
@@ -1,0 +1,26 @@
+package ai.philterd.test.phileas.model.metadata.zipcode;
+
+import ai.philterd.phileas.model.metadata.zipcode.ZipCodeMetadataRequest;
+import ai.philterd.phileas.model.metadata.zipcode.ZipCodeMetadataResponse;
+import ai.philterd.phileas.model.metadata.zipcode.ZipCodeMetadataService;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+
+public class ZipCodeMetadataServiceTest {
+
+    @Test
+    public void test() throws IOException {
+
+        final ZipCodeMetadataService zipCodeMetadataService = new ZipCodeMetadataService();
+
+        final ZipCodeMetadataRequest zipCodeMetadataRequest = new ZipCodeMetadataRequest("90210");
+
+        final ZipCodeMetadataResponse zipCodeMetadataResponse = zipCodeMetadataService.getMetadata(zipCodeMetadataRequest);
+
+        Assertions.assertEquals(21741, zipCodeMetadataResponse.getPopulation());
+
+    }
+
+}


### PR DESCRIPTION
### Description
Removes the `commons-csv` dependency that's only used for loading the zip code populations.

### Issues Resolved
Closes #173 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
