### PR TITLE
Enable outputting the replacement value on PDFs

### DIFF
--- a/docs/docs/filter_policies/pdf.md
+++ b/docs/docs/filter_policies/pdf.md
@@ -1,0 +1,40 @@
+# PDF Redaction Configuration
+
+PDF redaction can be configured through the `config.pdf` path of a policy.
+
+The available options are:
+
+| Key                      | Type      | Default     | Description                                                                                                                       |
+|--------------------------|-----------|-------------|-----------------------------------------------------------------------------------------------------------------------------------|
+| `redactionColor`         | `string`  | `black`     | This is the color of the redaction boxes that are drawn over the PII. Available options are `white`, `black`, `red`, and `yellow` |
+| `showReplacement`        | `boolean` | `false`     | If `true` then the output of the filter's strategy will be output on the redaction box in the PDF                                 |
+| `replacementFont`        | `string`  | `helvetica` | The font to use for the replacement output. Available options are `helvetica`, `times`, and `courier`                             |
+| `replacementMaxFontSize` | `float`   | `12`        | The maximum font size for the replacement text. Best efforts will be made to fit the replacement text within the redaction box    |
+| `replacementFontColor`   | `string`  | `white`     | The font color for the replacement. Available options match the `redactionColor` options                                          |
+
+### An Example PDF Configuration Policy
+
+The following is an example policy setting the PDF redaction options.
+
+```
+{
+   "name": "example-pdf-policy",
+   "identifiers": {
+      "emailAddress": {
+         "emailAddressFilterStrategies": [
+            {
+               "strategy": "REDACT",
+               "redactionFormat": "{{{REDACTED-%t}}}"
+            }
+         ]
+      }
+   },
+   "config": {
+     "pdf": {
+        "redactionColor": "red",
+        "showReplacement": true,
+        "replacementFontColor": "yellow"
+     }
+   }
+}
+```

--- a/phileas-core/src/test/java/ai/philterd/test/phileas/services/EndToEndTestsHelper.java
+++ b/phileas-core/src/test/java/ai/philterd/test/phileas/services/EndToEndTestsHelper.java
@@ -62,6 +62,11 @@ import ai.philterd.phileas.model.policy.filters.strategies.rules.UrlFilterStrate
 import ai.philterd.phileas.model.policy.filters.strategies.rules.VinFilterStrategy;
 import ai.philterd.phileas.model.policy.filters.strategies.rules.ZipCodeFilterStrategy;
 import org.apache.commons.io.FileUtils;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.apache.pdfbox.Loader;
+import org.apache.pdfbox.pdmodel.PDDocument;
+import org.apache.pdfbox.text.PDFTextStripper;
 
 import java.io.File;
 import java.io.IOException;
@@ -72,6 +77,7 @@ import java.util.List;
 import java.util.Set;
 
 public class EndToEndTestsHelper {
+    private static final Logger LOGGER = LogManager.getLogger(EndToEndTestsHelper.class);
 
 
     public static Policy getPolicyWithSentiment(String policyName) throws IOException {
@@ -454,4 +460,16 @@ public class EndToEndTestsHelper {
 
     }
 
+    public static boolean documentContainsText(byte[] doc, String needle) throws IOException {
+        try (PDDocument pdDocument = Loader.loadPDF(doc)) {
+            PDFTextStripper textStripper = new PDFTextStripper();
+            String pdfText = textStripper.getText(pdDocument);
+
+            if(pdfText.trim().isEmpty()) {
+                LOGGER.warn("documentContainsText called on a PDF with no text streams");
+            }
+
+            return pdfText.contains(needle);
+        }
+    }
 }

--- a/phileas-core/src/test/java/ai/philterd/test/phileas/services/PhileasFilterServiceTest.java
+++ b/phileas-core/src/test/java/ai/philterd/test/phileas/services/PhileasFilterServiceTest.java
@@ -46,6 +46,7 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Properties;
 
+import static ai.philterd.test.phileas.services.EndToEndTestsHelper.documentContainsText;
 import static ai.philterd.test.phileas.services.EndToEndTestsHelper.getPdfPolicy;
 import static ai.philterd.test.phileas.services.EndToEndTestsHelper.getPolicy;
 
@@ -106,6 +107,8 @@ public class PhileasFilterServiceTest {
         final byte[] document = IOUtils.toByteArray(is);
         is.close();
 
+        Assertions.assertTrue(documentContainsText(document, "Wendy"));
+
         final Path temp = Files.createTempDirectory("philter");
 
         final File file1 = Paths.get(temp.toFile().getAbsolutePath(), "pdf.json").toFile();
@@ -131,8 +134,10 @@ public class PhileasFilterServiceTest {
         LOGGER.info("Spans: {}", response.getExplanation().appliedSpans().size());
         showSpans(response.getExplanation().appliedSpans());
 
-        // TODO: How to assert? MD5 gives a different value each time.
-
+        // TODO: This is asserting that it doesn't contain anything as a text stream
+        // but it's possible that they're in the images, we would need to OCR
+        // the files for this assertion to be truly valuable
+        Assertions.assertFalse(documentContainsText(response.getDocument(), "Wendy"));
     }
 
     @Test
@@ -141,6 +146,8 @@ public class PhileasFilterServiceTest {
         final InputStream is = this.getClass().getResourceAsStream("/pdfs/new-lines.pdf");
         final byte[] document = IOUtils.toByteArray(is);
         is.close();
+
+        Assertions.assertTrue(documentContainsText(document, "90210"));
 
         final Path temp = Files.createTempDirectory("philter");
 
@@ -170,7 +177,10 @@ public class PhileasFilterServiceTest {
         // output:
         // characterStart: 35;  characterEnd: 40;  filterType: zip-code;  context: context;  documentId: documentid;  confidence: 0.9;  text: 90210;  replacement: {{{REDACTED-zip-code}}};  salt: ;  ignored: false;  classification: null;
 
-        // TODO: How to assert? MD5 gives a different value each time.
+        // TODO: This is asserting that it doesn't contain anything as a text stream
+        // but it's possible that they're in the images, we would need to OCR
+        // the files for this assertion to be truly valuable
+        Assertions.assertFalse(documentContainsText(response.getDocument(), "90210"));
 
     }
 

--- a/phileas-model/src/main/java/ai/philterd/phileas/model/policy/config/Pdf.java
+++ b/phileas-model/src/main/java/ai/philterd/phileas/model/policy/config/Pdf.java
@@ -20,9 +20,21 @@ import com.google.gson.annotations.SerializedName;
 
 public class Pdf {
 
-    @SerializedName("enabled")
+    @SerializedName("redactionColor")
     @Expose
     private String redactionColor = "black";
+
+    @SerializedName("redactionFont")
+    @Expose
+    private String redactionFont = "Helvetica";
+
+    @SerializedName("redactionFontSize")
+    @Expose
+    private float redactionFontSize = 12;
+
+    @SerializedName("redactionFontColor")
+    @Expose
+    private String redactionFontColor;
 
     public String getRedactionColor() {
         return redactionColor;
@@ -32,4 +44,19 @@ public class Pdf {
         this.redactionColor = redactionColor;
     }
 
+    public String getRedactionFont() {
+        return redactionFont;
+    }
+
+    public void setRedactionFont(String redactionFont) {
+        this.redactionFont = redactionFont;
+    }
+
+    public float getRedactionFontSize() {
+        return redactionFontSize;
+    }
+
+    public String getRedactionFontColor() {
+        return redactionFontColor;
+    }
 }

--- a/phileas-model/src/main/java/ai/philterd/phileas/model/policy/config/Pdf.java
+++ b/phileas-model/src/main/java/ai/philterd/phileas/model/policy/config/Pdf.java
@@ -24,39 +24,51 @@ public class Pdf {
     @Expose
     private String redactionColor = "black";
 
-    @SerializedName("redactionFont")
+    @SerializedName("showReplacement")
     @Expose
-    private String redactionFont = "Helvetica";
+    private boolean showReplacement = false;
 
-    @SerializedName("redactionFontSize")
+    @SerializedName("replacementFont")
     @Expose
-    private float redactionFontSize = 12;
+    private String replacementFont = "helvetica";
 
-    @SerializedName("redactionFontColor")
+    @SerializedName("replacementMaxFontSize")
     @Expose
-    private String redactionFontColor;
+    private float replacementMaxFontSize = 12;
+
+    @SerializedName("replacementFontColor")
+    @Expose
+    private String replacementFontColor;
 
     public String getRedactionColor() {
         return redactionColor;
     }
 
-    public void setRedactionColor(String redactionColor) {
-        this.redactionColor = redactionColor;
+    public void setRedactionColor(String replacementColor) {
+        this.redactionColor = replacementColor;
     }
 
-    public String getRedactionFont() {
-        return redactionFont;
+    public String getReplacementFont() {
+        return replacementFont;
     }
 
-    public void setRedactionFont(String redactionFont) {
-        this.redactionFont = redactionFont;
+    public void setReplacementFont(String replacementFont) {
+        this.replacementFont = replacementFont;
     }
 
-    public float getRedactionFontSize() {
-        return redactionFontSize;
+    public float getReplacementMaxFontSize() {
+        return replacementMaxFontSize;
     }
 
-    public String getRedactionFontColor() {
-        return redactionFontColor;
+    public String getReplacementFontColor() {
+        return replacementFontColor;
+    }
+
+    public boolean getShowReplacement() {
+        return showReplacement;
+    }
+
+    public void setShowReplacement(boolean showReplacement) {
+        this.showReplacement = showReplacement;
     }
 }


### PR DESCRIPTION
### Description
Enables outputting/replacing the text in PDFs by including the replacement value inside of the redaction box.

Best efforts are given to ensure that the text does not expand beyond the bounds of the box. This does, however, create scenarios where the box is really small so the font size ends up being tiny and not supremely useful.

Somewhat readable example:
<img width="551" alt="Screenshot 2024-12-17 at 16 38 04" src="https://github.com/user-attachments/assets/c48b1f81-1314-481f-8803-8578388e920f" />

Indecipherable example:
<img width="351" alt="Screenshot 2024-12-17 at 16 38 18" src="https://github.com/user-attachments/assets/e02c6668-cdb0-49c9-9a2d-594b4265509c" />

I'm wondering if this is something that should be disabled by default.

There also needs to be some documentation written for the PDF configuration portion of the policy.

### Issues Resolved
_List any issues this PR will resolve, e.g. Closes [...]._ 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
