### PR TITLE
PDF Redaction improvements

### DIFF
--- a/docs/docs/filter_policies/pdf.md
+++ b/docs/docs/filter_policies/pdf.md
@@ -4,16 +4,17 @@ PDF redaction can be configured through the `config.pdf` path of a policy.
 
 The available options are:
 
-| Key                      | Type      | Default     | Description                                                                                                                       |
-|--------------------------|-----------|-------------|-----------------------------------------------------------------------------------------------------------------------------------|
-| `redactionColor`         | `string`  | `black`     | This is the color of the redaction boxes that are drawn over the PII. Available options are `white`, `black`, `red`, and `yellow` |
-| `showReplacement`        | `boolean` | `false`     | If `true` then the output of the filter's strategy will be output on the redaction box in the PDF                                 |
-| `replacementFont`        | `string`  | `helvetica` | The font to use for the replacement output. Available options are `helvetica`, `times`, and `courier`                             |
-| `replacementMaxFontSize` | `float`   | `12`        | The maximum font size for the replacement text. Best efforts will be made to fit the replacement text within the redaction box    |
-| `replacementFontColor`   | `string`  | `white`     | The font color for the replacement. Available options match the `redactionColor` options                                          |
-| `scaling`                | `float`   | `1`         | The scaling factor to use when generating pdf image pages                                                                         |
-| `dpi`                    | `int`     | `150`       | The DPI resolution for the  output pdf image page                                                                                 |
-| `compressionQuality`     | `float`   | `1`         | Sets the compression quality to a value between 0 and 1. See javax.imageio.ImageWriteParam for more details                       |
+| Key                        | Type      | Default     | Description                                                                                                                       |
+|----------------------------|-----------|-------------|-----------------------------------------------------------------------------------------------------------------------------------|
+| `redactionColor`           | `string`  | `black`     | This is the color of the redaction boxes that are drawn over the PII. Available options are `white`, `black`, `red`, and `yellow` |
+| `showReplacement`          | `boolean` | `false`     | If `true` then the output of the filter's strategy will be output on the redaction box in the PDF                                 |
+| `replacementFont`          | `string`  | `helvetica` | The font to use for the replacement output. Available options are `helvetica`, `times`, and `courier`                             |
+| `replacementMaxFontSize`   | `float`   | `12`        | The maximum font size for the replacement text. Best efforts will be made to fit the replacement text within the redaction box    |
+| `replacementFontColor`     | `string`  | `white`     | The font color for the replacement. Available options match the `redactionColor` options                                          |
+| `scaling`                  | `float`   | `1`         | The scaling factor to use when generating pdf image pages                                                                         |
+| `dpi`                      | `int`     | `150`       | The DPI resolution for the  output pdf image page                                                                                 |
+| `compressionQuality`       | `float`   | `1`         | Sets the compression quality to a value between 0 and 1. See javax.imageio.ImageWriteParam for more details                       |
+| `preserveUnredactedPages`  | `boolean` | `false`     | If `true`, will transpose original PDF page to resulting document if no redaction is required on that page                        |
 
 ### An Example PDF Configuration Policy
 

--- a/docs/docs/filter_policies/pdf.md
+++ b/docs/docs/filter_policies/pdf.md
@@ -11,6 +11,9 @@ The available options are:
 | `replacementFont`        | `string`  | `helvetica` | The font to use for the replacement output. Available options are `helvetica`, `times`, and `courier`                             |
 | `replacementMaxFontSize` | `float`   | `12`        | The maximum font size for the replacement text. Best efforts will be made to fit the replacement text within the redaction box    |
 | `replacementFontColor`   | `string`  | `white`     | The font color for the replacement. Available options match the `redactionColor` options                                          |
+| `scaling`                | `float`   | `1`         | The scaling factor to use when generating pdf image pages                                                                         |
+| `dpi`                    | `int`     | `150`       | The DPI resolution for the  output pdf image page                                                                                 |
+| `compressionQuality`     | `float`   | `1`         | Sets the compression quality to a value between 0 and 1. See javax.imageio.ImageWriteParam for more details                       |
 
 ### An Example PDF Configuration Policy
 

--- a/phileas-core/src/main/java/ai/philterd/phileas/services/PhileasFilterService.java
+++ b/phileas-core/src/main/java/ai/philterd/phileas/services/PhileasFilterService.java
@@ -27,6 +27,7 @@ import ai.philterd.phileas.model.objects.PdfRedactionOptions;
 import ai.philterd.phileas.model.objects.Span;
 import ai.philterd.phileas.model.policy.Ignored;
 import ai.philterd.phileas.model.policy.Policy;
+import ai.philterd.phileas.model.policy.config.Pdf;
 import ai.philterd.phileas.model.policy.graphical.BoundingBox;
 import ai.philterd.phileas.model.responses.BinaryDocumentFilterResponse;
 import ai.philterd.phileas.model.responses.FilterResponse;
@@ -322,11 +323,14 @@ public class PhileasFilterService implements FilterService {
 
             }
 
-            // TODO: Build this from the config in the policy.
-            final PdfRedactionOptions pdfRedactionOptions = new PdfRedactionOptions();
-            pdfRedactionOptions.setDpi(150);
-            pdfRedactionOptions.setScale(0.25f);
-            pdfRedactionOptions.setCompressionQuality(1.0f);
+            // Load the Pdf config from the policy and apply to the PdfRedactionOptions that are used when
+            // generating the new PDF document from the result of the redaction
+            final Pdf policyPdfConfig = policy.getConfig().getPdf();
+            final PdfRedactionOptions pdfRedactionOptions = new PdfRedactionOptions(
+                    policyPdfConfig.getDpi(),
+                    policyPdfConfig.getCompressionQuality(),
+                    policyPdfConfig.getScale()
+            );
 
             // Redact those terms in the document along with any bounding boxes identified in the policy.
             final List<BoundingBox> boundingBoxes = getBoundingBoxes(policy, mimeType);

--- a/phileas-core/src/main/java/ai/philterd/phileas/services/PhileasFilterService.java
+++ b/phileas-core/src/main/java/ai/philterd/phileas/services/PhileasFilterService.java
@@ -329,7 +329,8 @@ public class PhileasFilterService implements FilterService {
             final PdfRedactionOptions pdfRedactionOptions = new PdfRedactionOptions(
                     policyPdfConfig.getDpi(),
                     policyPdfConfig.getCompressionQuality(),
-                    policyPdfConfig.getScale()
+                    policyPdfConfig.getScale(),
+                    policyPdfConfig.getPreserveUnredactedPages()
             );
 
             // Redact those terms in the document along with any bounding boxes identified in the policy.

--- a/phileas-model/src/main/java/ai/philterd/phileas/model/objects/PdfRedactionOptions.java
+++ b/phileas-model/src/main/java/ai/philterd/phileas/model/objects/PdfRedactionOptions.java
@@ -20,15 +20,17 @@ public class PdfRedactionOptions extends RedactionOptions {
     private int dpi = 150;
     private float compressionQuality = 1.0F;
     private float scale = 1.0F;
+    private boolean preserveUnredactedPages = false;
 
     public PdfRedactionOptions() {
 
     }
 
-    public PdfRedactionOptions(final int dpi, final float compressionQuality, final float scale) {
+    public PdfRedactionOptions(final int dpi, final float compressionQuality, final float scale, final boolean preserveUnredactedPages) {
         this.dpi = dpi;
         this.compressionQuality = compressionQuality;
         this.scale = scale;
+        this.preserveUnredactedPages = preserveUnredactedPages;
     }
 
     public int getDpi() {
@@ -53,6 +55,12 @@ public class PdfRedactionOptions extends RedactionOptions {
 
     public void setScale(float scale) {
         this.scale = scale;
+    }
+
+    public boolean getPreserveUnredactedPages() { return preserveUnredactedPages; }
+
+    public void setPreserveUnredactedPages(boolean preserveUnredactedPages) {
+        this.preserveUnredactedPages = preserveUnredactedPages;
     }
 
 }

--- a/phileas-model/src/main/java/ai/philterd/phileas/model/policy/config/Pdf.java
+++ b/phileas-model/src/main/java/ai/philterd/phileas/model/policy/config/Pdf.java
@@ -42,7 +42,7 @@ public class Pdf {
 
     @SerializedName("scale")
     @Expose
-    private float scale = 1.0f;
+    private float scale = 0.25f;
 
     @SerializedName("dpi")
     @Expose

--- a/phileas-model/src/main/java/ai/philterd/phileas/model/policy/config/Pdf.java
+++ b/phileas-model/src/main/java/ai/philterd/phileas/model/policy/config/Pdf.java
@@ -40,6 +40,18 @@ public class Pdf {
     @Expose
     private String replacementFontColor;
 
+    @SerializedName("scale")
+    @Expose
+    private float scale = 1.0f;
+
+    @SerializedName("dpi")
+    @Expose
+    private int dpi = 150;
+
+    @SerializedName("compressionQuality")
+    @Expose
+    private float compressionQuality = 1.0f;
+
     public String getRedactionColor() {
         return redactionColor;
     }
@@ -70,5 +82,29 @@ public class Pdf {
 
     public void setShowReplacement(boolean showReplacement) {
         this.showReplacement = showReplacement;
+    }
+
+    public float getScale() {
+        return scale;
+    }
+
+    public void setScale(float scaling) {
+        this.scale = scaling;
+    }
+
+    public int getDpi() {
+        return dpi;
+    }
+
+    public void setDpi(int dpi) {
+        this.dpi = dpi;
+    }
+
+    public float getCompressionQuality() {
+        return compressionQuality;
+    }
+
+    public void setCompressionQuality(float compressionQuality) {
+        this.compressionQuality = compressionQuality;
     }
 }

--- a/phileas-model/src/main/java/ai/philterd/phileas/model/policy/config/Pdf.java
+++ b/phileas-model/src/main/java/ai/philterd/phileas/model/policy/config/Pdf.java
@@ -52,6 +52,10 @@ public class Pdf {
     @Expose
     private float compressionQuality = 1.0f;
 
+    @SerializedName("preserveUnredactedPages")
+    @Expose
+    private boolean preserveUnredactedPages = false;
+
     public String getRedactionColor() {
         return redactionColor;
     }
@@ -106,5 +110,13 @@ public class Pdf {
 
     public void setCompressionQuality(float compressionQuality) {
         this.compressionQuality = compressionQuality;
+    }
+
+    public boolean getPreserveUnredactedPages() {
+        return preserveUnredactedPages;
+    }
+
+    public void setPreserveUnredactedPages(boolean preserveUnredactedPages) {
+        this.preserveUnredactedPages = preserveUnredactedPages;
     }
 }

--- a/phileas-model/src/test/java/ai/philterd/test/phileas/model/policy/config/PdfTest.java
+++ b/phileas-model/src/test/java/ai/philterd/test/phileas/model/policy/config/PdfTest.java
@@ -1,0 +1,28 @@
+package ai.philterd.test.phileas.model.policy.config;
+
+import ai.philterd.phileas.model.policy.config.Pdf;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+public class PdfTest {
+
+    @Test
+    public void canSetPdfRedactorOptions() {
+        Pdf pdfConfig = new Pdf();
+
+        pdfConfig.setRedactionColor("black");
+        pdfConfig.setReplacementFont("helvetica");
+        pdfConfig.setShowReplacement(true);
+        pdfConfig.setScale(1.0f);
+        pdfConfig.setDpi(150);
+        pdfConfig.setCompressionQuality(0.5f);
+
+        Assertions.assertEquals("black", pdfConfig.getRedactionColor());
+        Assertions.assertEquals("helvetica", pdfConfig.getReplacementFont());
+        Assertions.assertTrue(pdfConfig.getShowReplacement());
+        Assertions.assertEquals(1.0f, pdfConfig.getScale());
+        Assertions.assertEquals(150, pdfConfig.getDpi());
+        Assertions.assertEquals(0.5f, pdfConfig.getCompressionQuality());
+    }
+
+}

--- a/phileas-model/src/test/java/ai/philterd/test/phileas/model/policy/config/PdfTest.java
+++ b/phileas-model/src/test/java/ai/philterd/test/phileas/model/policy/config/PdfTest.java
@@ -10,19 +10,34 @@ public class PdfTest {
     public void canSetPdfRedactorOptions() {
         Pdf pdfConfig = new Pdf();
 
-        pdfConfig.setRedactionColor("black");
-        pdfConfig.setReplacementFont("helvetica");
+        pdfConfig.setRedactionColor("blue");
+        pdfConfig.setReplacementFont("times");
         pdfConfig.setShowReplacement(true);
-        pdfConfig.setScale(1.0f);
-        pdfConfig.setDpi(150);
+        pdfConfig.setScale(2.0f);
+        pdfConfig.setDpi(300);
         pdfConfig.setCompressionQuality(0.5f);
+        pdfConfig.setPreserveUnredactedPages(true);
+
+        Assertions.assertEquals("blue", pdfConfig.getRedactionColor());
+        Assertions.assertEquals("times", pdfConfig.getReplacementFont());
+        Assertions.assertTrue(pdfConfig.getShowReplacement());
+        Assertions.assertEquals(2.0f, pdfConfig.getScale());
+        Assertions.assertEquals(300, pdfConfig.getDpi());
+        Assertions.assertEquals(0.5f, pdfConfig.getCompressionQuality());
+        Assertions.assertTrue(pdfConfig.getPreserveUnredactedPages());
+    }
+
+    @Test
+    public void defaultsAreSetProperly() {
+        Pdf pdfConfig = new Pdf();
 
         Assertions.assertEquals("black", pdfConfig.getRedactionColor());
         Assertions.assertEquals("helvetica", pdfConfig.getReplacementFont());
-        Assertions.assertTrue(pdfConfig.getShowReplacement());
-        Assertions.assertEquals(1.0f, pdfConfig.getScale());
+        Assertions.assertEquals(12, pdfConfig.getReplacementMaxFontSize());
+        Assertions.assertEquals(0.25f, pdfConfig.getScale());
         Assertions.assertEquals(150, pdfConfig.getDpi());
-        Assertions.assertEquals(0.5f, pdfConfig.getCompressionQuality());
+        Assertions.assertEquals(1.0f, pdfConfig.getCompressionQuality());
+        Assertions.assertFalse(pdfConfig.getPreserveUnredactedPages());
     }
 
 }

--- a/phileas-services/phileas-services-pdf/src/test/java/ai/philterd/PdfRedacterTest.java
+++ b/phileas-services/phileas-services-pdf/src/test/java/ai/philterd/PdfRedacterTest.java
@@ -38,6 +38,7 @@ import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
 import java.io.File;
+import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.file.Files;
@@ -57,9 +58,8 @@ public class PdfRedacterTest {
 
     @Test
     public void testPDF1() throws IOException {
-
-        final Span span1 = Span.make(0, 1, FilterType.AGE, "ctx", "docid", 0.25, "Wendy", "repl", null, false, true, null);
-        final Span span2 = Span.make(0, 1, FilterType.AGE, "ctx", "docid", 0.25, "Bankruptcy", "repl", null, false, true, null);
+        final Span span1 = Span.make(0, 1, FilterType.AGE, "ctx", "docid", 0.25, "Bankruptcy", "repl", null, false, true, null);
+        final Span span2 = Span.make(0, 1, FilterType.AGE, "ctx", "docid", 0.25, "William", "repl", null, false, true, null);
         final Set<Span> spans = Set.copyOf(Arrays.asList(span1, span2));
 
         final String filename = "33011-pdf-118-pages.pdf"; //"12-12110 K.pdf";
@@ -92,7 +92,8 @@ public class PdfRedacterTest {
     public void testPDF2() throws IOException {
 
         final Span span1 = Span.make(0, 1, FilterType.DATE, "ctx", "docid", 0.25, "July 3, 2012", "||||", null, false, true, null);
-        final Set<Span> spans = Set.copyOf(Arrays.asList(span1));
+        final Span span2 = Span.make(0, 1, FilterType.AGE, "ctx", "docid", 0.25, "Wendy", "repl", null, false, true, null);
+        final Set<Span> spans = Set.copyOf(Arrays.asList(span1, span2));
 
         final String filename = "12-12110 K.pdf";
         final InputStream is = getClass().getClassLoader().getResourceAsStream(filename);


### PR DESCRIPTION
### Description

These changes accomplish two main goals:

- Extend the Pdf configuration object to allow passing of scale, dpi and compression quality that is used to determine these values in the PdfExtractor. This was previously not possible as the values were hard-coded in PhileasFilterService.
- Alters the manner in which PdfExtractor renders pages in the output PDF. If redaction is not necessary, the original, untouched PDPage is transposed to the output PDF. This not only retains quality for these pages, but also drastically improves speed (as there's much less image manipulation) and drastically reduces size of the output pdf. 

The second item is of interest to my team as we are regularly redacting documents that are quite large and skipping pages that don't need redaction cuts the processing time/size by a large degree.

### Issues Resolved
There was no issue opened for these. I searched for some but couldn't find any. I'm happy to open one or more issues if you'd like to document this behavior.
 
Please let me know if you need anything else. These features would be of great value so anything I can do to help along the PR I'd be happy to jump in. Thank you!

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
