### PR TITLE
Change behavior for zip codes that don't exist.

### DIFF
--- a/phileas-model/src/main/java/ai/philterd/phileas/model/metadata/zipcode/ZipCodeMetadataResponse.java
+++ b/phileas-model/src/main/java/ai/philterd/phileas/model/metadata/zipcode/ZipCodeMetadataResponse.java
@@ -20,13 +20,24 @@ import ai.philterd.phileas.model.metadata.MetadataResponse;
 public class ZipCodeMetadataResponse extends MetadataResponse {
 
     private final int population;
+    private final boolean exists;
 
     public ZipCodeMetadataResponse(int population) {
         this.population = population;
+        this.exists = true;
+    }
+
+    public ZipCodeMetadataResponse(int population, boolean exists) {
+        this.population = population;
+        this.exists = exists;
     }
 
     public int getPopulation() {
         return population;
+    }
+
+    public boolean isExists() {
+        return exists;
     }
 
 }

--- a/phileas-model/src/main/java/ai/philterd/phileas/model/metadata/zipcode/ZipCodeMetadataService.java
+++ b/phileas-model/src/main/java/ai/philterd/phileas/model/metadata/zipcode/ZipCodeMetadataService.java
@@ -36,7 +36,12 @@ public class ZipCodeMetadataService implements MetadataService<ZipCodeMetadataRe
 
         final int population = zipCodes2010Census.getOrDefault(request.getZipCode(), -1);
 
-        return new ZipCodeMetadataResponse(population);
+        if(population == -1) {
+            // The zip code was not found.
+            return new ZipCodeMetadataResponse(-1, false);
+        } else {
+            return new ZipCodeMetadataResponse(population);
+        }
 
     }
 

--- a/phileas-model/src/main/java/ai/philterd/phileas/model/policy/filters/strategies/rules/ZipCodeFilterStrategy.java
+++ b/phileas-model/src/main/java/ai/philterd/phileas/model/policy/filters/strategies/rules/ZipCodeFilterStrategy.java
@@ -74,19 +74,29 @@ public class ZipCodeFilterStrategy extends AbstractFilterStrategy {
                 final int value = Integer.parseInt(parsedCondition.getValue());
 
                 final ZipCodeMetadataResponse response = zipCodeMetadataService.getMetadata(new ZipCodeMetadataRequest(token));
-                final long populationForZipCode = response.getPopulation();
 
-                if (StringUtils.equalsIgnoreCase(POPULATION, parsedCondition.getField())) {
+                if(response.isExists()) {
 
-                    conditionsSatisfied = switch (parsedCondition.getOperator()) {
-                        case GREATER_THAN -> (populationForZipCode > value);
-                        case LESS_THAN -> (populationForZipCode < value);
-                        case GREATER_THAN_EQUALS -> (populationForZipCode >= value);
-                        case LESS_THAN_EQUALS -> (populationForZipCode <= value);
-                        case EQUALS -> (populationForZipCode == value);
-                        case NOT_EQUALS -> (populationForZipCode != value);
-                        default -> conditionsSatisfied;
-                    };
+                    final long populationForZipCode = response.getPopulation();
+
+                    if (StringUtils.equalsIgnoreCase(POPULATION, parsedCondition.getField())) {
+
+                        conditionsSatisfied = switch (parsedCondition.getOperator()) {
+                            case GREATER_THAN -> (populationForZipCode > value);
+                            case LESS_THAN -> (populationForZipCode < value);
+                            case GREATER_THAN_EQUALS -> (populationForZipCode >= value);
+                            case LESS_THAN_EQUALS -> (populationForZipCode <= value);
+                            case EQUALS -> (populationForZipCode == value);
+                            case NOT_EQUALS -> (populationForZipCode != value);
+                            default -> conditionsSatisfied;
+                        };
+
+                    }
+
+                } else {
+
+                    // The zip code did not exist.
+                    conditionsSatisfied = false;
 
                 }
 

--- a/phileas-model/src/test/java/ai/philterd/test/phileas/model/policy/filters/strategies/rules/ZipCodeFilterStrategyTest.java
+++ b/phileas-model/src/test/java/ai/philterd/test/phileas/model/policy/filters/strategies/rules/ZipCodeFilterStrategyTest.java
@@ -112,6 +112,17 @@ public class ZipCodeFilterStrategyTest extends AbstractFilterStrategyTest {
     }
 
     @Test
+    public void evaluateConditionInvalidZipCode() throws IOException {
+
+        ZipCodeFilterStrategy strategy = new ZipCodeFilterStrategy();
+
+        final boolean conditionSatisfied = strategy.evaluateCondition(getPolicy(), "context", "documentid", "12345", WINDOW,"population > 1", 1.0, attributes);
+
+        Assertions.assertFalse(conditionSatisfied);
+
+    }
+
+    @Test
     public void staticReplacement1() throws Exception {
 
         ZipCodeFilterStrategy strategy = new ZipCodeFilterStrategy();


### PR DESCRIPTION
### Description
If a zip code in a conditional does not exist, the conditional will now fail. Previously, the zip code would be returned as having a population of `-1` which was not ideal because that might end up satisfying the conditional.

### Issues Resolved
Closes #175 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
