### PR TITLE
Removing metrics that can be tracked by the implementer.

### DIFF
--- a/phileas-core/src/main/java/ai/philterd/phileas/services/metrics/NoOpMetricsService.java
+++ b/phileas-core/src/main/java/ai/philterd/phileas/services/metrics/NoOpMetricsService.java
@@ -20,27 +20,13 @@ import ai.philterd.phileas.model.services.MetricsService;
 
 /**
  * An implementation of {@link MetricsService} that does nothing with the metrics.
+ * It is a placeholder and example implementation.
  */
 public class NoOpMetricsService implements MetricsService {
 
     @Override
-    public void incrementProcessed() {
-
-    }
-
-    @Override
-    public void incrementProcessed(long count) {
-
-    }
-
-    @Override
-    public void incrementFilterType(FilterType filterType) {
-
-    }
-
-    @Override
     public void logFilterTime(FilterType filterType, long timeMs) {
-
+        // Do nothing. This is a placeholder.
     }
 
 }

--- a/phileas-model/src/main/java/ai/philterd/phileas/model/services/MetricsService.java
+++ b/phileas-model/src/main/java/ai/philterd/phileas/model/services/MetricsService.java
@@ -17,11 +17,12 @@ package ai.philterd.phileas.model.services;
 
 import ai.philterd.phileas.model.enums.FilterType;
 
+/**
+ * The metrics service is intended to track _only_ things that an implementer
+ * of the Phileas library does _not_ have access to. Things like filter type counts
+ * can be tracked by the implementer so they should not be captured by this service.
+ */
 public interface MetricsService {
-
-    void incrementProcessed();
-    void incrementProcessed(long count);
-    void incrementFilterType(FilterType filterType);
 
     /**
      * The elapsed time for each filter.

--- a/phileas-processors/phileas-processors-unstructured/src/main/java/ai/philterd/phileas/processors/unstructured/UnstructuredDocumentProcessor.java
+++ b/phileas-processors/phileas-processors-unstructured/src/main/java/ai/philterd/phileas/processors/unstructured/UnstructuredDocumentProcessor.java
@@ -133,9 +133,6 @@ public class UnstructuredDocumentProcessor implements DocumentProcessor {
 
         // TODO: Set a flag on each "span" not in appliedSpans indicating it was not used.
 
-        // Log a metric for each filter type.
-        appliedSpans.forEach(k -> metricsService.incrementFilterType(k.getFilterType()));
-
         // Define the explanation.
         final Explanation explanation = new Explanation(appliedSpans, identifiedSpans);
 
@@ -185,8 +182,6 @@ public class UnstructuredDocumentProcessor implements DocumentProcessor {
             }
 
         }
-
-        metricsService.incrementProcessed();
 
         return new FilterResponse(sb.toString(), context, documentId, piece, explanation, attributes);
 


### PR DESCRIPTION
### Description
Removes metrics from `MetricsService` that can be tracked by the implementer.

### Issues Resolved
Closes #224 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
