### PR TITLE
Changing PolicyService to use Policy objects instead of strings

### DIFF
--- a/phileas-core/src/main/java/ai/philterd/phileas/services/PhileasFilterService.java
+++ b/phileas-core/src/main/java/ai/philterd/phileas/services/PhileasFilterService.java
@@ -28,7 +28,6 @@ import ai.philterd.phileas.model.policy.config.Pdf;
 import ai.philterd.phileas.model.policy.graphical.BoundingBox;
 import ai.philterd.phileas.model.responses.BinaryDocumentFilterResponse;
 import ai.philterd.phileas.model.responses.FilterResponse;
-import ai.philterd.phileas.model.serializers.PlaceholderDeserializer;
 import ai.philterd.phileas.model.services.AlertService;
 import ai.philterd.phileas.model.services.CacheService;
 import ai.philterd.phileas.model.services.Classification;
@@ -54,8 +53,6 @@ import ai.philterd.phileas.services.postfilters.TrailingSpacePostFilter;
 import ai.philterd.phileas.services.split.SplitFactory;
 import ai.philterd.services.pdf.PdfRedacter;
 import ai.philterd.services.pdf.PdfTextExtractor;
-import com.google.gson.Gson;
-import com.google.gson.GsonBuilder;
 import org.apache.commons.codec.digest.DigestUtils;
 import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.lang3.StringUtils;
@@ -98,11 +95,8 @@ public class PhileasFilterService implements FilterService {
 
         this.filterCache = new ConcurrentHashMap<>();
 
-        // Configure the deserialization.
-        final Gson gson = new GsonBuilder().registerTypeAdapter(String.class, new PlaceholderDeserializer()).create();
-
         this.policyService = policyService;
-        this.policyUtils = new PolicyUtils(policyService, gson);
+        this.policyUtils = new PolicyUtils(policyService);
 
         // Set the alert service.
         this.alertService = new DefaultAlertService(cacheService);

--- a/phileas-core/src/test/java/ai/philterd/test/phileas/services/EndToEndTests.java
+++ b/phileas-core/src/test/java/ai/philterd/test/phileas/services/EndToEndTests.java
@@ -90,7 +90,7 @@ public class EndToEndTests {
         final PhileasConfiguration phileasConfiguration = new PhileasConfiguration(properties);
 
         final PolicyService policyService = new InMemoryPolicyService();
-        policyService.save(gson.toJson(getPolicy("default")));
+        policyService.save(getPolicy("default"));
 
         final PhileasFilterService service = new PhileasFilterService(phileasConfiguration, cacheService, policyService);
         final FilterResponse response = service.filter(List.of("default"), "context", "documentid", "George Washington was president and his ssn was 123-45-6789 and he lived at 90210.", MimeType.TEXT_PLAIN);
@@ -109,7 +109,7 @@ public class EndToEndTests {
         final PhileasConfiguration phileasConfiguration = new PhileasConfiguration(properties);
 
         final PolicyService policyService = new InMemoryPolicyService();
-        policyService.save(gson.toJson(getPolicy("default")));
+        policyService.save(getPolicy("default"));
 
         final PhileasFilterService service = new PhileasFilterService(phileasConfiguration, cacheService, policyService);
         final FilterResponse response = service.filter(List.of("default"), "context", "documentid", "My email is test@something.com and cc is 4121742025464465", MimeType.TEXT_PLAIN);
@@ -128,7 +128,7 @@ public class EndToEndTests {
         final PhileasConfiguration phileasConfiguration = new PhileasConfiguration(properties);
 
         final PolicyService policyService = new InMemoryPolicyService();
-        policyService.save(gson.toJson(getPolicy("default")));
+        policyService.save(getPolicy("default"));
 
         final PhileasFilterService service = new PhileasFilterService(phileasConfiguration, cacheService, policyService);
         final FilterResponse response = service.filter(List.of("default"), "context", "documentid", "test@something.com is email and cc is 4121742025464465", MimeType.TEXT_PLAIN);
@@ -147,7 +147,7 @@ public class EndToEndTests {
         final PhileasConfiguration phileasConfiguration = new PhileasConfiguration(properties);
 
         final PolicyService policyService = new InMemoryPolicyService();
-        policyService.save(gson.toJson(getPolicy("default")));
+        policyService.save(getPolicy("default"));
 
         final PhileasFilterService service = new PhileasFilterService(phileasConfiguration, cacheService, policyService);
         final FilterResponse response = service.filter(List.of("default"), "context", "documentid", "test@something.com", MimeType.TEXT_PLAIN);
@@ -166,7 +166,7 @@ public class EndToEndTests {
         final PhileasConfiguration phileasConfiguration = new PhileasConfiguration(properties);
 
         final PolicyService policyService = new InMemoryPolicyService();
-        policyService.save(gson.toJson(getPolicy("default")));
+        policyService.save(getPolicy("default"));
 
         final PhileasFilterService service = new PhileasFilterService(phileasConfiguration, cacheService, policyService);
         final FilterResponse response = service.filter(List.of("default"), "context", "documentid", "90210", MimeType.TEXT_PLAIN);
@@ -185,7 +185,7 @@ public class EndToEndTests {
         final PhileasConfiguration phileasConfiguration = new PhileasConfiguration(properties);
 
         final PolicyService policyService = new InMemoryPolicyService();
-        policyService.save(gson.toJson(getPolicy("default")));
+        policyService.save(getPolicy("default"));
 
         final PhileasFilterService service = new PhileasFilterService(phileasConfiguration, cacheService, policyService);
         final FilterResponse response = service.filter(List.of("default"), "context", "documentid", "his name was JEFF.", MimeType.TEXT_PLAIN);
@@ -204,7 +204,7 @@ public class EndToEndTests {
         final PhileasConfiguration phileasConfiguration = new PhileasConfiguration(properties);
 
         final PolicyService policyService = new InMemoryPolicyService();
-        policyService.save(gson.toJson(getPolicy("default")));
+        policyService.save(getPolicy("default"));
 
         final PhileasFilterService service = new PhileasFilterService(phileasConfiguration, cacheService, policyService);
         final FilterResponse response = service.filter(List.of("default"), "context", "documentid", "he was seen on 10-19-2020.", MimeType.TEXT_PLAIN);
@@ -223,7 +223,7 @@ public class EndToEndTests {
         final PhileasConfiguration phileasConfiguration = new PhileasConfiguration(properties);
 
         final PolicyService policyService = new InMemoryPolicyService();
-        policyService.save(gson.toJson(getPolicy("default")));
+        policyService.save(getPolicy("default"));
 
         final PhileasFilterService service = new PhileasFilterService(phileasConfiguration, cacheService, policyService);
         final FilterResponse response = service.filter(List.of("default"), "context", "documentid",
@@ -243,7 +243,7 @@ public class EndToEndTests {
         final PhileasConfiguration phileasConfiguration = new PhileasConfiguration(properties);
 
         final PolicyService policyService = new InMemoryPolicyService();
-        policyService.save(gson.toJson(getPolicy("default")));
+        policyService.save(getPolicy("default"));
 
         final PhileasFilterService service = new PhileasFilterService(phileasConfiguration, cacheService, policyService);
         final FilterResponse response = service.filter(List.of("default"), "context", "documentid", "George Washington was president and his ssn was 123-45-6789 and he lived at 90210. The name 456 should be filtered. Jeff Smith should be ignored.", MimeType.TEXT_PLAIN);
@@ -262,7 +262,7 @@ public class EndToEndTests {
         final PhileasConfiguration phileasConfiguration = new PhileasConfiguration(properties);
 
         final PolicyService policyService = new InMemoryPolicyService();
-        policyService.save(gson.toJson(getPolicy("default")));
+        policyService.save(getPolicy("default"));
 
         final String input = IOUtils.toString(this.getClass().getResourceAsStream("/inputs/1.txt"), Charset.defaultCharset());
 
@@ -286,7 +286,7 @@ public class EndToEndTests {
         final PhileasConfiguration phileasConfiguration = new PhileasConfiguration(properties);
 
         final PolicyService policyService = new InMemoryPolicyService();
-        policyService.save(gson.toJson(getPolicy("default")));
+        policyService.save(getPolicy("default"));
 
         final String input = "IN THE UNITED STATES DISTRICT COURT \nEASTERN DISTRICT OF ARKANSAS \nWESTERN DIVISION \nJAMES EDWARD SMITH, \nafk/a James Edward Bridges, \nADC#103093 \nv. No. 4:14-cv-455-DPM \nPLAINTIFF \nCHARLES A. SMITH; \nMARY ANN CONLEY, \nafk/a Mary Ann Smith; and \nROBERT CASTILLOW DEFENDANTS \nORDER \nJames Smith's prose complaint must be dismissed without prejudice. \nHe hasn't paid the filing fee, moved to proceed in forma pauperis, or provided \nproof of service on any defendant. FED. R. CIV. P. 4(I); Local Rule 5.5(c)(2). \nSo Ordered. \nD.P. Marshall Jr. \nUnited States District Judge \nCase 4:14-cv-00455-DPM   Document 2   Filed 12/09/14   Page 1 of 1\n";
 
@@ -307,7 +307,7 @@ public class EndToEndTests {
         final PhileasConfiguration phileasConfiguration = new PhileasConfiguration(properties);
 
         final PolicyService policyService = new InMemoryPolicyService();
-        policyService.save(gson.toJson(getPolicy("default")));
+        policyService.save(getPolicy("default"));
 
         final String input = IOUtils.toString(this.getClass().getResourceAsStream("/inputs/Oxford_City_unveil_merger_to_expand_their_youth_system.json.txt"), Charset.defaultCharset());
 
@@ -331,7 +331,7 @@ public class EndToEndTests {
         final PhileasConfiguration phileasConfiguration = new PhileasConfiguration(properties);
 
         final PolicyService policyService = new InMemoryPolicyService();
-        policyService.save(gson.toJson(getPolicy("default")));
+        policyService.save(getPolicy("default"));
 
         final String input = IOUtils.toString(this.getClass().getResourceAsStream("/inputs/Kinross_reports_strong_2020_secondquarter_results.json.txt"), Charset.defaultCharset());
 
@@ -355,7 +355,7 @@ public class EndToEndTests {
         final PhileasConfiguration phileasConfiguration = new PhileasConfiguration(properties);
 
         final PolicyService policyService = new InMemoryPolicyService();
-        policyService.save(gson.toJson(getPolicy("default")));
+        policyService.save(getPolicy("default"));
 
         final String input = IOUtils.toString(this.getClass().getResourceAsStream("/inputs/Donations_to_Black_Lives_Matter_Group_Dont_Go_to_DNC.json.txt"), Charset.defaultCharset());
 
@@ -379,7 +379,7 @@ public class EndToEndTests {
         final PhileasConfiguration phileasConfiguration = new PhileasConfiguration(properties);
 
         final PolicyService policyService = new InMemoryPolicyService();
-        policyService.save(gson.toJson(getPolicy("default")));
+        policyService.save(getPolicy("default"));
 
         final String input = IOUtils.toString(this.getClass().getResourceAsStream("/inputs/Fantasy_Baseball_Winners__Losers_Sixto_Sanchez_and_Jeff_McNeil_stay_hot.json.txt"), Charset.defaultCharset());
 
@@ -403,7 +403,7 @@ public class EndToEndTests {
         final PhileasConfiguration phileasConfiguration = new PhileasConfiguration(properties);
 
         final PolicyService policyService = new InMemoryPolicyService();
-        policyService.save(gson.toJson(getPolicy("default")));
+        policyService.save(getPolicy("default"));
 
         final String input = "the id is 123456.";
 
@@ -427,7 +427,7 @@ public class EndToEndTests {
         final PhileasConfiguration phileasConfiguration = new PhileasConfiguration(properties);
 
         final PolicyService policyService = new InMemoryPolicyService();
-        policyService.save(gson.toJson(getPolicyJustStreetAddress("streetaddress")));
+        policyService.save(getPolicyJustStreetAddress("streetaddress"));
 
         final String input = "he lived at 100 main street";
 
@@ -482,7 +482,7 @@ public class EndToEndTests {
         final CacheService inMemoryCache = new InMemoryCache();
         
         final PolicyService policyService = new InMemoryPolicyService();
-        policyService.save(gson.toJson(policy));
+        policyService.save(policy);
         
         final String input = "the payment method is 4532613702852251 visa or 1Lbcfr7sAHTD9CgdQo3HTMTkV8LK4ZnX71 BTC from user.";
 
@@ -510,7 +510,7 @@ public class EndToEndTests {
         final PhileasConfiguration phileasConfiguration = new PhileasConfiguration(properties);
 
         final PolicyService policyService = new InMemoryPolicyService();
-        policyService.save(gson.toJson(getPolicyJustPhoneNumber("phonenumbers")));
+        policyService.save(getPolicyJustPhoneNumber("phonenumbers"));
 
         final String input = "his number is 123-456-7890. her number is 9999999999. her number is 102-304-5678.";
 
@@ -541,7 +541,7 @@ public class EndToEndTests {
         final PhileasConfiguration phileasConfiguration = new PhileasConfiguration(properties);
 
         final PolicyService policyService = new InMemoryPolicyService();
-        policyService.save(gson.toJson(policy));
+        policyService.save(policy);
 
         final String input = "he lived at 100 main street";
 
@@ -565,7 +565,7 @@ public class EndToEndTests {
         final PhileasConfiguration phileasConfiguration = new PhileasConfiguration(properties);
 
         final PolicyService policyService = new InMemoryPolicyService();
-        policyService.save(gson.toJson(getPolicyWithSentiment("sentiment")));
+        policyService.save(getPolicyWithSentiment("sentiment"));
 
         final String input = "his ssn was 123-45-6789";
 
@@ -598,7 +598,7 @@ public class EndToEndTests {
         final PhileasConfiguration phileasConfiguration = new PhileasConfiguration(properties);
 
         final PolicyService policyService = new InMemoryPolicyService();
-        policyService.save(gson.toJson(policy));
+        policyService.save(policy);
 
         final PhileasFilterService service = new PhileasFilterService(phileasConfiguration, cacheService, policyService);
         final FilterResponse response = service.filter(List.of("default"), "context", "documentid", "his name was samuel and george.", MimeType.TEXT_PLAIN);
@@ -634,7 +634,7 @@ public class EndToEndTests {
         final PhileasConfiguration phileasConfiguration = new PhileasConfiguration(properties);
 
         final PolicyService policyService = new InMemoryPolicyService();
-        policyService.save(gson.toJson(policy));
+        policyService.save(policy);
 
         final PhileasFilterService service = new PhileasFilterService(phileasConfiguration, cacheService, policyService);
         final FilterResponse response = service.filter(List.of("default"), "context", "documentid", "his name was samuel and george.", MimeType.TEXT_PLAIN);
@@ -669,7 +669,7 @@ public class EndToEndTests {
         final PhileasConfiguration phileasConfiguration = new PhileasConfiguration(properties);
 
         final PolicyService policyService = new InMemoryPolicyService();
-        policyService.save(gson.toJson(policy));
+        policyService.save(policy);
 
         final PhileasFilterService service = new PhileasFilterService(phileasConfiguration, cacheService, policyService);
         final FilterResponse response = service.filter(List.of("default"), "context", "documentid", "his name was samuel.", MimeType.TEXT_PLAIN);
@@ -688,7 +688,7 @@ public class EndToEndTests {
         final PhileasConfiguration phileasConfiguration = new PhileasConfiguration(properties);
 
         final PolicyService policyService = new InMemoryPolicyService();
-        policyService.save(gson.toJson(getPolicy("default")));
+        policyService.save(getPolicy("default"));
 
         final PhileasFilterService service = new PhileasFilterService(phileasConfiguration, cacheService, policyService);
         final FilterResponse response = service.filter(List.of("default"), "context", null, "his name was JEFF.", MimeType.TEXT_PLAIN);
@@ -708,8 +708,8 @@ public class EndToEndTests {
         final PhileasConfiguration phileasConfiguration = new PhileasConfiguration(properties);
 
         final PolicyService policyService = new InMemoryPolicyService();
-        policyService.save(gson.toJson(getPolicy("default")));
-        policyService.save(gson.toJson(getPolicyJustCreditCard("justcreditcard")));
+        policyService.save(getPolicy("default"));
+        policyService.save(getPolicyJustCreditCard("justcreditcard"));
 
         final PhileasFilterService service = new PhileasFilterService(phileasConfiguration, cacheService, policyService);
         final FilterResponse response = service.filter(List.of("justcreditcard"), "context", "documentid", "My email is test@something.com", MimeType.TEXT_PLAIN);
@@ -727,7 +727,7 @@ public class EndToEndTests {
         final PhileasConfiguration phileasConfiguration = new PhileasConfiguration(properties);
 
         final PolicyService policyService = new InMemoryPolicyService();
-        policyService.save(gson.toJson(getPolicyJustCreditCard("justcreditcard")));
+        policyService.save(getPolicyJustCreditCard("justcreditcard"));
 
         final PhileasFilterService service = new PhileasFilterService(phileasConfiguration, cacheService, policyService);
         final FilterResponse response = service.filter(List.of("justcreditcard"), "context", "documentid", "My cc is 4121742025464465", MimeType.TEXT_PLAIN);
@@ -745,7 +745,7 @@ public class EndToEndTests {
         final PhileasConfiguration phileasConfiguration = new PhileasConfiguration(properties);
 
         final PolicyService policyService = new InMemoryPolicyService();
-        policyService.save(gson.toJson(getPolicyJustCreditCardNotInUnixTimestamps("justcreditcard")));
+        policyService.save(getPolicyJustCreditCardNotInUnixTimestamps("justcreditcard"));
 
         final PhileasFilterService service = new PhileasFilterService(phileasConfiguration, cacheService, policyService);
         final FilterResponse response = service.filter(List.of("justcreditcard"), "context", "documentid", "My cc is 1647725122227", MimeType.TEXT_PLAIN);
@@ -763,7 +763,7 @@ public class EndToEndTests {
         final PhileasConfiguration phileasConfiguration = new PhileasConfiguration(properties);
 
         final PolicyService policyService = new InMemoryPolicyService();
-        policyService.save(gson.toJson(getPolicyJustCreditCard("justcreditcard")));
+        policyService.save(getPolicyJustCreditCard("justcreditcard"));
 
         final PhileasFilterService service = new PhileasFilterService(phileasConfiguration, cacheService, policyService);
         final FilterResponse response = service.filter(List.of("justcreditcard"), "context", "documentid", "My cc is 4121742025464400", MimeType.TEXT_PLAIN);
@@ -781,7 +781,7 @@ public class EndToEndTests {
         final PhileasConfiguration phileasConfiguration = new PhileasConfiguration(properties);
 
         final PolicyService policyService = new InMemoryPolicyService();
-        policyService.save(gson.toJson(getPolicyZipCodeWithIgnored("default")));
+        policyService.save(getPolicyZipCodeWithIgnored("default"));
 
         final PhileasFilterService service = new PhileasFilterService(phileasConfiguration, cacheService, policyService);
         final FilterResponse response = service.filter(List.of("default"), "context", "documentid", "George Washington was president and his ssn was 123-45-6789 and he lived at 90210.", MimeType.TEXT_PLAIN);
@@ -799,7 +799,7 @@ public class EndToEndTests {
         final PhileasConfiguration phileasConfiguration = new PhileasConfiguration(properties);
 
         final PolicyService policyService = new InMemoryPolicyService();
-        policyService.save(gson.toJson(getPolicy("default")));
+        policyService.save(getPolicy("default"));
 
         final PhileasFilterService service = new PhileasFilterService(phileasConfiguration, cacheService, policyService);
         final FilterResponse response = service.filter(List.of("default"), "context", "documentid", "George Washington was president and his ssn was 123-45-6789 and he lived at 90210.", MimeType.TEXT_PLAIN);
@@ -817,7 +817,7 @@ public class EndToEndTests {
         final PhileasConfiguration phileasConfiguration = new PhileasConfiguration(properties);
 
         final PolicyService policyService = new InMemoryPolicyService();
-        policyService.save(gson.toJson(getPolicy("default")));
+        policyService.save(getPolicy("default"));
 
         Assertions.assertThrows(FileNotFoundException.class, () -> {
 

--- a/phileas-core/src/test/java/ai/philterd/test/phileas/services/PhileasFilterServiceTest.java
+++ b/phileas-core/src/test/java/ai/philterd/test/phileas/services/PhileasFilterServiceTest.java
@@ -115,7 +115,7 @@ public class PhileasFilterServiceTest {
         final PhileasConfiguration phileasConfiguration = new PhileasConfiguration(properties);
 
         final PolicyService policyService = new InMemoryPolicyService();
-        policyService.save(gson.toJson(getPdfPolicy("pdf")));
+        policyService.save(getPdfPolicy("pdf"));
 
         final PhileasFilterService service = new PhileasFilterService(phileasConfiguration, cacheService, policyService);
         final BinaryDocumentFilterResponse response = service.filter(List.of("pdf"), "context", "documentid", document, MimeType.APPLICATION_PDF, MimeType.APPLICATION_PDF);
@@ -149,7 +149,7 @@ public class PhileasFilterServiceTest {
         final PhileasConfiguration phileasConfiguration = new PhileasConfiguration(properties);
 
         final PolicyService policyService = new InMemoryPolicyService();
-        policyService.save(gson.toJson(getPdfPolicy("pdf")));
+        policyService.save(getPdfPolicy("pdf"));
 
         PhileasFilterService service = new PhileasFilterService(phileasConfiguration, cacheService, policyService);
         final BinaryDocumentFilterResponse response = service.filter(Arrays.asList("pdf"), "context", "documentid", document, MimeType.APPLICATION_PDF, MimeType.APPLICATION_PDF);

--- a/phileas-model/src/main/java/ai/philterd/phileas/model/services/PolicyService.java
+++ b/phileas-model/src/main/java/ai/philterd/phileas/model/services/PolicyService.java
@@ -15,6 +15,8 @@
  */
 package ai.philterd.phileas.model.services;
 
+import ai.philterd.phileas.model.policy.Policy;
+
 import java.io.IOException;
 import java.util.List;
 import java.util.Map;
@@ -33,23 +35,23 @@ public interface PolicyService {
      * Gets the content of a policy.
      * @param policyName The name of the policy.
      * @return The policy.
-     * @throws IOException Thrown if a policy can not be read.
+     * @throws IOException Thrown if a policy cannot be read.
      */
-    String get(String policyName) throws IOException;
+    Policy get(String policyName) throws IOException;
 
     /**
      * Get the names and content of all policies.
      * @return A map of policy names to policy content.
      * @throws IOException Thrown if the policies cannot be read.
      */
-    Map<String, String> getAll() throws IOException;
+    Map<String, Policy> getAll() throws IOException;
 
     /**
      * Saves a policy.
-     * @param policyJson The content of the policy as JSON.
+     * @param policy The content of the policy as JSON.
      * @throws IOException Thrown if the policy cannot be saved.
      */
-    void save(String policyJson) throws IOException;
+    void save(Policy policy) throws IOException;
 
     /**
      * Deletes a policy.

--- a/phileas-services/phileas-services-policies/src/main/java/ai/philterd/phileas/services/policies/InMemoryPolicyService.java
+++ b/phileas-services/phileas-services-policies/src/main/java/ai/philterd/phileas/services/policies/InMemoryPolicyService.java
@@ -16,11 +16,12 @@
 package ai.philterd.phileas.services.policies;
 
 import ai.philterd.phileas.model.exceptions.api.BadRequestException;
+import ai.philterd.phileas.model.policy.Policy;
 import ai.philterd.phileas.model.services.PolicyService;
+import com.google.gson.Gson;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.json.JSONException;
-import org.json.JSONObject;
 
 import java.io.IOException;
 import java.util.HashMap;
@@ -31,10 +32,12 @@ public class InMemoryPolicyService implements PolicyService {
 
     private static final Logger LOGGER = LogManager.getLogger(InMemoryPolicyService.class);
 
-    private final Map<String, String> policies;
+    private final Map<String, Policy> policies;
+    private final Gson gson;
 
     public InMemoryPolicyService() {
         this.policies = new HashMap<>();
+        this.gson = new Gson();
     }
 
     @Override
@@ -45,28 +48,27 @@ public class InMemoryPolicyService implements PolicyService {
     }
 
     @Override
-    public String get(String policyName) throws IOException {
+    public Policy get(String policyName) throws IOException {
 
         return policies.get(policyName);
 
     }
 
     @Override
-    public Map<String, String> getAll() throws IOException {
+    public Map<String, Policy> getAll() throws IOException {
 
         return policies;
 
     }
 
     @Override
-    public void save(String policyJson) {
+    public void save(Policy policy) {
+
+        final String policyJson = gson.toJson(policy);
 
         try {
 
-            final JSONObject object = new JSONObject(policyJson);
-            final String policyName = object.getString("name");
-
-            policies.put(policyName, policyJson);
+            policies.put(policy.getName(), policy);
 
         } catch (JSONException ex) {
 

--- a/phileas-services/phileas-services-policies/src/main/java/ai/philterd/phileas/services/policies/InMemoryPolicyService.java
+++ b/phileas-services/phileas-services-policies/src/main/java/ai/philterd/phileas/services/policies/InMemoryPolicyService.java
@@ -18,7 +18,6 @@ package ai.philterd.phileas.services.policies;
 import ai.philterd.phileas.model.exceptions.api.BadRequestException;
 import ai.philterd.phileas.model.policy.Policy;
 import ai.philterd.phileas.model.services.PolicyService;
-import com.google.gson.Gson;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.json.JSONException;
@@ -33,11 +32,9 @@ public class InMemoryPolicyService implements PolicyService {
     private static final Logger LOGGER = LogManager.getLogger(InMemoryPolicyService.class);
 
     private final Map<String, Policy> policies;
-    private final Gson gson;
 
     public InMemoryPolicyService() {
         this.policies = new HashMap<>();
-        this.gson = new Gson();
     }
 
     @Override
@@ -55,7 +52,7 @@ public class InMemoryPolicyService implements PolicyService {
     }
 
     @Override
-    public Map<String, Policy> getAll() throws IOException {
+    public Map<String, Policy> getAll() {
 
         return policies;
 
@@ -63,8 +60,6 @@ public class InMemoryPolicyService implements PolicyService {
 
     @Override
     public void save(Policy policy) {
-
-        final String policyJson = gson.toJson(policy);
 
         try {
 

--- a/phileas-services/phileas-services-policies/src/main/java/ai/philterd/phileas/services/policies/utils/PolicyUtils.java
+++ b/phileas-services/phileas-services-policies/src/main/java/ai/philterd/phileas/services/policies/utils/PolicyUtils.java
@@ -15,7 +15,6 @@
  */
 package ai.philterd.phileas.services.policies.utils;
 
-import com.google.gson.Gson;
 import ai.philterd.phileas.model.enums.FilterType;
 import ai.philterd.phileas.model.policy.Policy;
 import ai.philterd.phileas.model.services.PolicyService;
@@ -29,14 +28,10 @@ public class PolicyUtils {
 
     private static final Logger LOGGER = LogManager.getLogger(PolicyUtils.class);
 
-    private PolicyService policyService;
-    private Gson gson;
+    private final PolicyService policyService;
 
-    public PolicyUtils(PolicyService policyService, Gson gson) {
-
+    public PolicyUtils(final PolicyService policyService) {
         this.policyService = policyService;
-        this.gson = gson;
-
     }
 
     public Policy getCombinedPolicies(final List<String> policyNames) throws IOException, IllegalStateException {
@@ -45,7 +40,7 @@ public class PolicyUtils {
         // By starting off with a full policy we don't have to worry about adding
         // Config and Crypto (and other sections) since those will always be
         // taken from the first policy.
-        final Policy combinedPolicy = getPolicy(policyNames.get(0));
+        final Policy combinedPolicy = policyService.get(policyNames.get(0));
 
         // In some chases there may be only one policy.
         if(policyNames.size() > 1) {
@@ -58,7 +53,7 @@ public class PolicyUtils {
             for (final String policyName : policyNames.subList(1, policyNames.size())) {
 
                 // Get the policy.
-                final Policy policy = getPolicy(policyName);
+                final Policy policy = policyService.get(policyName);
 
                 // For each of the filter types, copy the filter (if it exists) from the source policy
                 // to the destination (combined) policy. If a filter already exists in the destination (combined)
@@ -88,17 +83,6 @@ public class PolicyUtils {
         }
 
         return combinedPolicy;
-
-    }
-
-    private Policy getPolicy(String policyName) throws IOException {
-
-        // This will ALWAYS return a policy because if it is not in the cache it will be retrieved from the cache.
-        // TODO: How to trigger a reload if the policy had to be retrieved from disk?
-        final String policyJson = policyService.get(policyName);
-
-        LOGGER.debug("Deserializing policy [{}]", policyName);
-        return gson.fromJson(policyJson, Policy.class);
 
     }
 

--- a/phileas-services/phileas-services-policies/src/test/java/ai/philterd/test/phileas/services/policies/InMemoryPolicyServiceTest.java
+++ b/phileas-services/phileas-services-policies/src/test/java/ai/philterd/test/phileas/services/policies/InMemoryPolicyServiceTest.java
@@ -40,8 +40,8 @@ public class InMemoryPolicyServiceTest {
 
         final PolicyService policyService = new InMemoryPolicyService();
 
-        policyService.save(gson.toJson(getPolicy("name1")));
-        policyService.save(gson.toJson(getPolicy("name2")));
+        policyService.save(getPolicy("name1"));
+        policyService.save(getPolicy("name2"));
 
         final List<String> names = policyService.get();
 
@@ -56,10 +56,10 @@ public class InMemoryPolicyServiceTest {
 
         final PolicyService policyService = new InMemoryPolicyService();
 
-        policyService.save(gson.toJson(getPolicy("name1")));
-        policyService.save(gson.toJson(getPolicy("name2")));
+        policyService.save(getPolicy("name1"));
+        policyService.save(getPolicy("name2"));
 
-        final Map<String, String> all = policyService.getAll();
+        final Map<String, Policy> all = policyService.getAll();
 
         Assertions.assertEquals(2, all.size());
         Assertions.assertTrue(all.containsKey("name1"));
@@ -72,13 +72,13 @@ public class InMemoryPolicyServiceTest {
 
         final String name = "default";
 
-        final String policy = gson.toJson(getPolicy(name));
+        final Policy policy = getPolicy(name);
 
         final PolicyService policyService = new InMemoryPolicyService();
 
         policyService.save(policy);
 
-        final String saved = policyService.get("default");
+        final Policy saved = policyService.get("default");
 
         Assertions.assertNotNull(saved);
         Assertions.assertEquals(policy, saved);
@@ -90,13 +90,13 @@ public class InMemoryPolicyServiceTest {
 
         final String name = "default";
 
-        final String policy = gson.toJson(getPolicy(name));
+        final Policy policy = getPolicy(name);
 
         final PolicyService policyService = new InMemoryPolicyService();
 
         policyService.save(policy);
 
-        final String policyJson = policyService.get(name);
+        final Policy policyJson = policyService.get(name);
 
         Assertions.assertEquals(policy, policyJson);
 
@@ -106,7 +106,7 @@ public class InMemoryPolicyServiceTest {
     public void delete() throws IOException {
 
         final String name = "default";
-        final String policy = gson.toJson(getPolicy(name));
+        final Policy policy = getPolicy(name);
 
         final PolicyService policyService = new InMemoryPolicyService();
 

--- a/phileas-services/phileas-services-policies/src/test/java/ai/philterd/test/phileas/services/policies/utils/PolicyUtilsTest.java
+++ b/phileas-services/phileas-services-policies/src/test/java/ai/philterd/test/phileas/services/policies/utils/PolicyUtilsTest.java
@@ -15,11 +15,11 @@
  */
 package ai.philterd.test.phileas.services.policies.utils;
 
-import com.google.gson.Gson;
 import ai.philterd.phileas.model.enums.FilterType;
 import ai.philterd.phileas.model.policy.Policy;
 import ai.philterd.phileas.model.services.PolicyService;
 import ai.philterd.phileas.services.policies.utils.PolicyUtils;
+import com.google.gson.Gson;
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.junit.jupiter.api.Assertions;
@@ -35,6 +35,8 @@ import static org.mockito.Mockito.when;
 
 public class PolicyUtilsTest {
 
+    private final Gson gson = new Gson();
+
     @Disabled
     @Test
     public void onlyOne() throws IOException {
@@ -42,10 +44,9 @@ public class PolicyUtilsTest {
         final String json1 = IOUtils.toString(this.getClass().getResourceAsStream("/policies/policy1.json"), Charset.defaultCharset());
 
         final PolicyService policyService = Mockito.mock(PolicyService.class);
-        when(policyService.get("policy1")).thenReturn(json1);
+        when(policyService.get("policy1")).thenReturn(gson.fromJson(json1, Policy.class));
 
-        final Gson gson = new Gson();
-        final PolicyUtils policyUtils = new PolicyUtils(policyService, gson);
+        final PolicyUtils policyUtils = new PolicyUtils(policyService);
         final Policy policy = policyUtils.getCombinedPolicies(Arrays.asList("policy1"));
 
         final Policy originalPolicy = gson.fromJson(json1, Policy.class);
@@ -68,11 +69,10 @@ public class PolicyUtilsTest {
         final String json2 = IOUtils.toString(this.getClass().getResourceAsStream("/policies/policy2.json"), Charset.defaultCharset());
 
         final PolicyService policyService = Mockito.mock(PolicyService.class);
-        when(policyService.get("policy1")).thenReturn(json1);
-        when(policyService.get("policy2")).thenReturn(json2);
+        when(policyService.get("policy1")).thenReturn(gson.fromJson(json1, Policy.class));
+        when(policyService.get("policy2")).thenReturn(gson.fromJson(json2, Policy.class));
 
-        final Gson gson = new Gson();
-        final PolicyUtils policyUtils = new PolicyUtils(policyService, gson);
+        final PolicyUtils policyUtils = new PolicyUtils(policyService);
         final Policy policy = policyUtils.getCombinedPolicies(Arrays.asList("policy1", "policy2"));
 
         Assertions.assertNotNull(policy);
@@ -90,11 +90,10 @@ public class PolicyUtilsTest {
         final String json2 = IOUtils.toString(this.getClass().getResourceAsStream("/policies/policy1.json"), Charset.defaultCharset());
 
         final PolicyService policyService = Mockito.mock(PolicyService.class);
-        when(policyService.get("policy1")).thenReturn(json1);
-        when(policyService.get("policy2")).thenReturn(json2);
+        when(policyService.get("policy1")).thenReturn(gson.fromJson(json1, Policy.class));
+        when(policyService.get("policy2")).thenReturn(gson.fromJson(json2, Policy.class));
 
-        final Gson gson = new Gson();
-        final PolicyUtils policyUtils = new PolicyUtils(policyService, gson);
+        final PolicyUtils policyUtils = new PolicyUtils(policyService);
 
         Assertions.assertThrows(IllegalStateException.class, () -> {
             final Policy policy = policyUtils.getCombinedPolicies(Arrays.asList("policy1", "policy2"));
@@ -109,11 +108,10 @@ public class PolicyUtilsTest {
         final String json2 = IOUtils.toString(this.getClass().getResourceAsStream("/policies/policy4.json"), Charset.defaultCharset());
 
         final PolicyService policyService = Mockito.mock(PolicyService.class);
-        when(policyService.get("policy3")).thenReturn(json1);
-        when(policyService.get("policy4")).thenReturn(json2);
+        when(policyService.get("policy3")).thenReturn(gson.fromJson(json1, Policy.class));
+        when(policyService.get("policy4")).thenReturn(gson.fromJson(json2, Policy.class));
 
-        final Gson gson = new Gson();
-        final PolicyUtils policyUtils = new PolicyUtils(policyService, gson);
+        final PolicyUtils policyUtils = new PolicyUtils(policyService);
         final Policy policy = policyUtils.getCombinedPolicies(Arrays.asList("policy3", "policy4"));
 
         Assertions.assertNotNull(policy);
@@ -129,11 +127,10 @@ public class PolicyUtilsTest {
         final String json2 = IOUtils.toString(this.getClass().getResourceAsStream("/policies/policy6.json"), Charset.defaultCharset());
 
         final PolicyService policyService = Mockito.mock(PolicyService.class);
-        when(policyService.get("policy5")).thenReturn(json1);
-        when(policyService.get("policy6")).thenReturn(json2);
+        when(policyService.get("policy5")).thenReturn(gson.fromJson(json1, Policy.class));
+        when(policyService.get("policy6")).thenReturn(gson.fromJson(json2, Policy.class));
 
-        final Gson gson = new Gson();
-        final PolicyUtils policyUtils = new PolicyUtils(policyService, gson);
+        final PolicyUtils policyUtils = new PolicyUtils(policyService);
         final Policy policy = policyUtils.getCombinedPolicies(Arrays.asList("policy5", "policy6"));
 
         Assertions.assertNotNull(policy);
@@ -151,11 +148,10 @@ public class PolicyUtilsTest {
         final String json2 = IOUtils.toString(this.getClass().getResourceAsStream("/policies/policy5.json"), Charset.defaultCharset());
 
         final PolicyService policyService = Mockito.mock(PolicyService.class);
-        when(policyService.get("policy6")).thenReturn(json1);
-        when(policyService.get("policy5")).thenReturn(json2);
+        when(policyService.get("policy6")).thenReturn(gson.fromJson(json1, Policy.class));
+        when(policyService.get("policy5")).thenReturn(gson.fromJson(json2, Policy.class));
 
-        final Gson gson = new Gson();
-        final PolicyUtils policyUtils = new PolicyUtils(policyService, gson);
+        final PolicyUtils policyUtils = new PolicyUtils(policyService);
         final Policy policy = policyUtils.getCombinedPolicies(Arrays.asList("policy6", "policy5"));
 
         Assertions.assertNotNull(policy);
@@ -171,11 +167,10 @@ public class PolicyUtilsTest {
         final String json2 = IOUtils.toString(this.getClass().getResourceAsStream("/policies/policy5.json"), Charset.defaultCharset());
 
         final PolicyService policyService = Mockito.mock(PolicyService.class);
-        when(policyService.get("policy7")).thenReturn(json1);
-        when(policyService.get("policy5")).thenReturn(json2);
+        when(policyService.get("policy7")).thenReturn(gson.fromJson(json1, Policy.class));
+        when(policyService.get("policy5")).thenReturn(gson.fromJson(json2, Policy.class));
 
-        final Gson gson = new Gson();
-        final PolicyUtils policyUtils = new PolicyUtils(policyService, gson);
+        final PolicyUtils policyUtils = new PolicyUtils(policyService);
         final Policy policy = policyUtils.getCombinedPolicies(Arrays.asList("policy7", "policy5"));
 
         Assertions.assertNotNull(policy);
@@ -191,11 +186,10 @@ public class PolicyUtilsTest {
         final String json2 = IOUtils.toString(this.getClass().getResourceAsStream("/policies/policy9.json"), Charset.defaultCharset());
 
         final PolicyService policyService = Mockito.mock(PolicyService.class);
-        when(policyService.get("policy8")).thenReturn(json1);
-        when(policyService.get("policy9")).thenReturn(json2);
+        when(policyService.get("policy8")).thenReturn(gson.fromJson(json1, Policy.class));
+        when(policyService.get("policy9")).thenReturn(gson.fromJson(json2, Policy.class));
 
-        final Gson gson = new Gson();
-        final PolicyUtils policyUtils = new PolicyUtils(policyService, gson);
+        final PolicyUtils policyUtils = new PolicyUtils(policyService);
         final Policy policy = policyUtils.getCombinedPolicies(Arrays.asList("policy8", "policy9"));
 
         Assertions.assertNotNull(policy);
@@ -212,11 +206,10 @@ public class PolicyUtilsTest {
         final String json2 = IOUtils.toString(this.getClass().getResourceAsStream("/policies/policy11.json"), Charset.defaultCharset());
 
         final PolicyService policyService = Mockito.mock(PolicyService.class);
-        when(policyService.get("policy10")).thenReturn(json1);
-        when(policyService.get("policy11")).thenReturn(json2);
+        when(policyService.get("policy10")).thenReturn(gson.fromJson(json1, Policy.class));
+        when(policyService.get("policy11")).thenReturn(gson.fromJson(json2, Policy.class));
 
-        final Gson gson = new Gson();
-        final PolicyUtils policyUtils = new PolicyUtils(policyService, gson);
+        final PolicyUtils policyUtils = new PolicyUtils(policyService);
         final Policy policy = policyUtils.getCombinedPolicies(Arrays.asList("policy10", "policy11"));
 
         Assertions.assertNotNull(policy);


### PR DESCRIPTION
### Description
Changes `PolicyService` to use `Policy` objects instead of strings.

### Issues Resolved
Closes #226 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
