### PR TITLE
Removing alert on filter strategy

### DIFF
--- a/docs/docs/filter_policies/sample_filter_policies.md
+++ b/docs/docs/filter_policies/sample_filter_policies.md
@@ -189,25 +189,3 @@ This policy has a list of globally ignored terms.
   }
 }
 ```
-
-### Generating Alerts
-
-This policy generates an alert when a matching email address is identified.
-
-```
-{
-  "name": "email-address-alert",
-  "identifiers": {
-    "emailAddress": {
-      "emailAddressFilterStrategies": [
-        {
-          "strategy": "REDACT",
-          "redactionFormat": "{{{REDACTED-%t}}}",
-          "condition": "token == \"test@test.com\"",
-          "alert": true
-        }
-      ]
-    }
-  }
-}
-```

--- a/src/main/java/ai/philterd/phileas/services/strategies/AbstractFilterStrategy.java
+++ b/src/main/java/ai/philterd/phileas/services/strategies/AbstractFilterStrategy.java
@@ -122,10 +122,6 @@ public abstract class AbstractFilterStrategy {
     @Expose
     protected String condition = "";
 
-    @SerializedName("alert")
-    @Expose
-    protected boolean alert = false;
-
     @SerializedName("salt")
     @Expose
     protected boolean salt;
@@ -413,14 +409,6 @@ public abstract class AbstractFilterStrategy {
 
     public String getCondition() {
         return condition;
-    }
-
-    public boolean isAlert() {
-        return alert;
-    }
-
-    public void setAlert(boolean alert) {
-        this.alert = alert;
     }
 
     public boolean isSalt() {


### PR DESCRIPTION
### Description
Removes alert on filter strategy since alert service was removed in 3.0.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
