### PR TITLE
Fix IPv4 regex accepting matches that start/end mid-digit-run

### DIFF
--- a/src/main/java/ai/philterd/phileas/services/filters/regex/IpAddressFilter.java
+++ b/src/main/java/ai/philterd/phileas/services/filters/regex/IpAddressFilter.java
@@ -34,7 +34,11 @@ public class IpAddressFilter extends RegexFilter {
     public IpAddressFilter(FilterConfiguration filterConfiguration) {
         super(FilterType.IP_ADDRESS, filterConfiguration);
 
-        final Pattern ipv4Pattern = Pattern.compile("([01]?\\d\\d?|2[0-4]\\d|25[0-5])\\." + "([01]?\\d\\d?|2[0-4]\\d|25[0-5])\\." + "([01]?\\d\\d?|2[0-4]\\d|25[0-5])\\." + "([01]?\\d\\d?|2[0-4]\\d|25[0-5])");
+        // The per-octet alternation already carried most of this complexity before the (?<!\d)/(?!\d)
+        // boundaries added here for issues #335 and #336; splitting octet validation out of the regex
+        // and into post-match Java code would be a larger, separate change.
+        @SuppressWarnings("java:S5843")
+        final Pattern ipv4Pattern = Pattern.compile("(?<!\\d)([01]?\\d\\d?|2[0-4]\\d|25[0-5])\\." + "([01]?\\d\\d?|2[0-4]\\d|25[0-5])\\." + "([01]?\\d\\d?|2[0-4]\\d|25[0-5])\\." + "([01]?\\d\\d?|2[0-4]\\d|25[0-5])(?!\\d)");
 
         final FilterPattern ipv4 = new FilterPattern.FilterPatternBuilder(ipv4Pattern, 0.90).build();
 

--- a/src/test/java/ai/philterd/phileas/filters/IpAddressFilterTest.java
+++ b/src/test/java/ai/philterd/phileas/filters/IpAddressFilterTest.java
@@ -102,6 +102,42 @@ public class IpAddressFilterTest extends AbstractFilterTest {
     }
 
     @Test
+    public void filterIpv4AllOnesOctetNotTruncated() throws Exception {
+
+        // https://github.com/philterd/phileas/issues/335
+        final FilterConfiguration filterConfiguration = new FilterConfiguration.FilterConfigurationBuilder()
+                .withStrategies(List.of(new IpAddressFilterStrategy()))
+                .withWindowSize(windowSize)
+                .build();
+
+        final IpAddressFilter filter = new IpAddressFilter(filterConfiguration);
+
+        final Filtered filtered = filter.filter(contextService, getPolicy(), "context", PIECE, "ip 255.255.255.255");
+
+        Assertions.assertEquals(1, filtered.getSpans().size());
+        Assertions.assertTrue(checkSpan(filtered.getSpans().get(0), 3, 18, FilterType.IP_ADDRESS));
+        Assertions.assertEquals("255.255.255.255", filtered.getSpans().get(0).getText());
+
+    }
+
+    @Test
+    public void filterIpv4OutOfRangeLeadingOctetProducesNoSpan() throws Exception {
+
+        // https://github.com/philterd/phileas/issues/336
+        final FilterConfiguration filterConfiguration = new FilterConfiguration.FilterConfigurationBuilder()
+                .withStrategies(List.of(new IpAddressFilterStrategy()))
+                .withWindowSize(windowSize)
+                .build();
+
+        final IpAddressFilter filter = new IpAddressFilter(filterConfiguration);
+
+        final Filtered filtered = filter.filter(contextService, getPolicy(), "context", PIECE, "ip 256.1.1.1");
+
+        Assertions.assertEquals(0, filtered.getSpans().size());
+
+    }
+
+    @Test
     public void filterWithCandidates1() throws Exception {
 
         final List<String> candidates = List.of("1.1.1.1", "2.2.2.2");


### PR DESCRIPTION
Fixes #335
Fixes #336

## Root cause

Each octet alternative in `IpAddressFilter`'s IPv4 pattern only *constrains* 3-digit values (`[01]?\d\d?`, `2[0-4]\d`, `25[0-5]`); nothing in the pattern requires the engine to prefer the longest valid alternative. Without a boundary assertion at either end of the whole pattern, that produces two independent symptoms:

- **#335** — the last octet can match fewer digits than are actually present, because nothing after it forces backtracking into a longer alternative. For `255.255.255.255`, the first branch (`[01]?\d\d?`) greedily consumes `"25"` for the final octet and the match already succeeds, so the engine never backtracks to try `25[0-5]` against `"255"`. Result: `255.255.255.25`, one digit short.
- **#336** — an out-of-range leading octet fails every alternative at its own start position (`"256"` matches none of the three branches when followed by `.`), so `Matcher.find()` retries one character later and matches a valid-looking address hiding inside the invalid one. `256.1.1.1` becomes a match on `56.1.1.1` instead of producing no span.

## Fix

Wrap the existing pattern with `(?<!\d)` and `(?!\d)`:

```java
Pattern.compile("(?<!\d)([01]?\d\d?|2[0-4]\d|25[0-5])\." + ... + "([01]?\d\d?|2[0-4]\d|25[0-5])(?!\d)");
```

`(?!\d)` at the end forces the engine to backtrack out of the short alternative at the last octet whenever a digit follows, so it falls through to the alternative that actually consumes the full run. `(?<!\d)` at the start prevents a match from ever beginning partway through a longer digit run, closing the `find()`-retry path that produced the #336 false positive. Neither assertion consumes characters, so existing matches (including ones immediately followed by punctuation, like a URL or a sentence-ending period) are unaffected.

## Testing

- Standalone `Pattern`/`Matcher` reproduction of both bugs against the exact regex from the file, confirming the fix (and confirming it does *not* regress the sentence-trailing-period case or produce a false match against `1::`).
- Added `filterIpv4AllOnesOctetNotTruncated` and `filterIpv4OutOfRangeLeadingOctetProducesNoSpan` to `IpAddressFilterTest`, covering the exact reproducers from #335 and #336.
- `mvn -Dtest=IpAddressFilterTest test`: all 7 tests pass (5 existing + 2 new).
- Full suite (`mvn test`, JDK 25, Windows): 2044 tests, same 2 failures / 1 error as on `main` without this change (`DateFilterTest.filterDate34`, `EndToEndWithIncrementalRedactionsTest.endToEndWithSplits`, `PdfFilterServiceTest.testApply1` — the last is a Windows-path `FileNotFoundException` unrelated to this change). Verified via `git stash` that all three pre-exist on `main`.