### PR TITLE
Fix numeric date patterns accepting a short prefix of a longer token

### DIFF
--- a/src/main/java/ai/philterd/phileas/services/filters/regex/DateFilter.java
+++ b/src/main/java/ai/philterd/phileas/services/filters/regex/DateFilter.java
@@ -116,6 +116,10 @@ public class DateFilter extends RegexFilter {
      * Build the list of date filter patterns.
      * @return A list of {@link FilterPattern}.
      */
+    // Per-delimiter pattern construction (Pattern.compile() inside the loop, the "\d{2}"/"\d{4}"
+    // literals repeated across the four numeric templates) predates this fix; hoisting it into
+    // delimiter-independent constants would be a separate, larger restructuring of this method.
+    @SuppressWarnings({"java:S9142", "java:S1192"})
     private List<FilterPattern> buildFilterPatterns() {
 
         final List<FilterPattern> filterPatterns = new LinkedList<>();
@@ -139,18 +143,23 @@ public class DateFilter extends RegexFilter {
             // human-readable date format.
             final String d = Pattern.quote(delimiter);
 
+            // Neither a bare digit nor "delimiter + digit" may follow a match: the former blocks
+            // matching a short prefix of a longer number (e.g. "255" as "25"), the latter blocks
+            // matching a short prefix of a longer delimited chain (e.g. "1-20" out of "1-20-01023").
+            final String noMoreDigits = "(?!\\d)(?!" + d + "\\d)";
+
             // Make a filter pattern for each pattern with each delimiter. The numeric day/month/year
             // patterns carry a month-first format; day-first dates (e.g. 25/12/1980) that month-first
             // cannot validate are recovered in the filter() validation step, which retries the same
             // text as day-first. See toDayFirstFormat / validate().
-            filterPatterns.add(new FilterPattern.FilterPatternBuilder(Pattern.compile("\\b\\d{4}" + d + "\\d{2}" + d + "\\d{2}"), 0.75).withFormat("uuuu-MM-dd".replaceAll("-", delimiter)).build());
-            filterPatterns.add(new FilterPattern.FilterPatternBuilder(Pattern.compile("\\b\\d{2}" + d + "\\d{2}" + d + "\\d{4}"), 0.75).withFormat("MM-dd-uuuu".replaceAll("-", delimiter)).build());
-            filterPatterns.add(new FilterPattern.FilterPatternBuilder(Pattern.compile("\\b\\d{1,2}" + d + "\\d{1,2}" + d + "\\d{2,4}"), 75).withFormat("M-d-u".replaceAll("-", delimiter)).build());
+            filterPatterns.add(new FilterPattern.FilterPatternBuilder(Pattern.compile("\\b\\d{4}" + d + "\\d{2}" + d + "\\d{2}" + noMoreDigits), 0.75).withFormat("uuuu-MM-dd".replace("-", delimiter)).build());
+            filterPatterns.add(new FilterPattern.FilterPatternBuilder(Pattern.compile("\\b\\d{2}" + d + "\\d{2}" + d + "\\d{4}" + noMoreDigits), 0.75).withFormat("MM-dd-uuuu".replace("-", delimiter)).build());
+            filterPatterns.add(new FilterPattern.FilterPatternBuilder(Pattern.compile("\\b\\d{1,2}" + d + "\\d{1,2}" + d + "\\d{2,4}" + noMoreDigits), 75).withFormat("M-d-u".replace("-", delimiter)).build());
 
             // Month-and-year only. Not generated for the "." delimiter, where it would match decimals
             // such as 3.14.
             if(!".".equals(delimiter)) {
-                filterPatterns.add(new FilterPattern.FilterPatternBuilder(Pattern.compile("\\b\\d{1,2}" + d + "\\d{2,4}"), 75).withFormat("M-u".replaceAll("-", delimiter)).build());
+                filterPatterns.add(new FilterPattern.FilterPatternBuilder(Pattern.compile("\\b\\d{1,2}" + d + "\\d{2,4}" + noMoreDigits), 75).withFormat("M-u".replace("-", delimiter)).build());
             }
 
             filterPatterns.add(new FilterPattern.FilterPatternBuilder(Pattern.compile("(?i)(\\b\\d{1,2}\\D{0,3})?\\b(?:Jan(?:uary)?|Feb(?:ruary)?|Mar(?:ch)?|Apr(?:il)?|May|Jun(?:e)?|Jul(?:y)?|Aug(?:ust)?|Sep(?:tember)?|Oct(?:ober)?|(Nov|Dec)(?:ember)?)(\\.)?\\D?(\\d{1,2}(\\D?(st|nd|rd|th))?\\D?)(\\D?((19[7-9]\\d|20\\d{2})|\\d{2}))?\\b"), 0.75).withFormat("MMMM-dd".replaceAll("-", delimiter)).withAlwaysValid(true).build());

--- a/src/main/java/ai/philterd/phileas/services/filters/regex/DateFilter.java
+++ b/src/main/java/ai/philterd/phileas/services/filters/regex/DateFilter.java
@@ -146,7 +146,12 @@ public class DateFilter extends RegexFilter {
             // Neither a bare digit nor "delimiter + digit" may follow a match: the former blocks
             // matching a short prefix of a longer number (e.g. "255" as "25"), the latter blocks
             // matching a short prefix of a longer delimited chain (e.g. "1-20" out of "1-20-01023").
-            final String noMoreDigits = "(?!\\d)(?!" + d + "\\d)";
+            // The space delimiter is exempt from the second lookahead: space also separates ordinary
+            // words, so "space + digit" after a space-delimited date (e.g. "12 25 2020 4 days") is
+            // normal surrounding text, not a continuation of the same chain.
+            final String noMoreDigits = " ".equals(delimiter)
+                    ? "(?!\\d)"
+                    : "(?!\\d)(?!" + d + "\\d)";
 
             // Make a filter pattern for each pattern with each delimiter. The numeric day/month/year
             // patterns carry a month-first format; day-first dates (e.g. 25/12/1980) that month-first

--- a/src/test/java/ai/philterd/phileas/filters/DateFilterTest.java
+++ b/src/test/java/ai/philterd/phileas/filters/DateFilterTest.java
@@ -28,6 +28,9 @@ import java.util.List;
 
 import static ai.philterd.phileas.services.strategies.AbstractFilterStrategy.RANDOM_REPLACE;
 
+// The many near-identical test methods predate this fix; converting them to @ParameterizedTest
+// groups would be a separate, unrelated refactor of the whole file.
+@SuppressWarnings("java:S5976")
 public class DateFilterTest extends AbstractFilterTest {
     
     private FilterConfiguration buildFilterConfiguration() {
@@ -472,16 +475,31 @@ public class DateFilterTest extends AbstractFilterTest {
     @Test
     public void filterDate38() throws Exception {
 
+        // https://github.com/philterd/phileas/issues/341
+        // "12-12110" is 2 digits, a delimiter, and 5 digits: not a M-u shaped date. The pattern
+        // used to accept a truncated match ("12-1211") because it had no trailing boundary, so
+        // nothing stopped it from ignoring the digit run's last character.
         final DateFilter filter = new DateFilter(buildFilterConfiguration(), false, DateSpanValidator.getInstance());
 
         final Filtered filtered = filter.filter(contextService, getPolicy(), "context", PIECE, "Case No. 12-12110 K");
 
         showSpans(filtered.getSpans());
 
-        Assertions.assertEquals(1, filtered.getSpans().size());
-        Assertions.assertEquals(9, filtered.getSpans().get(0).getCharacterStart());
-        Assertions.assertEquals(16, filtered.getSpans().get(0).getCharacterEnd());
-        Assertions.assertEquals("12-1211", filtered.getSpans().get(0).getText());
+        Assertions.assertEquals(0, filtered.getSpans().size());
+
+    }
+
+    @Test
+    public void filterDate38b() throws Exception {
+
+        // https://github.com/philterd/phileas/issues/341
+        final DateFilter filter = new DateFilter(buildFilterConfiguration(), false, DateSpanValidator.getInstance());
+
+        final Filtered filtered = filter.filter(contextService, getPolicy(), "context", PIECE, "Case 1-20-01023-MJK");
+
+        showSpans(filtered.getSpans());
+
+        Assertions.assertEquals(0, filtered.getSpans().size());
 
     }
 

--- a/src/test/java/ai/philterd/phileas/filters/DateFilterTest.java
+++ b/src/test/java/ai/philterd/phileas/filters/DateFilterTest.java
@@ -504,6 +504,38 @@ public class DateFilterTest extends AbstractFilterTest {
     }
 
     @Test
+    public void filterDate38c() throws Exception {
+
+        // https://github.com/philterd/phileas/pull/347#pullrequestreview
+        // Space is also a word separator, so "date + space + digit" must not be treated the same
+        // as "date + delimiter + digit" for the '-'/'/' delimiters.
+        final DateFilter filter = new DateFilter(buildFilterConfiguration(), false, DateSpanValidator.getInstance());
+
+        final Filtered filtered = filter.filter(contextService, getPolicy(), "context", PIECE, "12 25 2020 4 days");
+
+        showSpans(filtered.getSpans());
+
+        Assertions.assertEquals(1, filtered.getSpans().size());
+        Assertions.assertEquals("12 25 2020", filtered.getSpans().get(0).getText());
+
+    }
+
+    @Test
+    public void filterDate38d() throws Exception {
+
+        // https://github.com/philterd/phileas/pull/347#pullrequestreview
+        final DateFilter filter = new DateFilter(buildFilterConfiguration(), false, DateSpanValidator.getInstance());
+
+        final Filtered filtered = filter.filter(contextService, getPolicy(), "context", PIECE, "01 15 2026 42 units");
+
+        showSpans(filtered.getSpans());
+
+        Assertions.assertEquals(1, filtered.getSpans().size());
+        Assertions.assertEquals("01 15 2026", filtered.getSpans().get(0).getText());
+
+    }
+
+    @Test
     public void filterDate39() throws Exception {
 
         final DateFilter filter = new DateFilter(buildFilterConfiguration(), true, DateSpanValidator.getInstance());


### PR DESCRIPTION
Fixes #341

Same bug family as #335 / #336, already fixed for `IpAddressFilter` in #346: each numeric date pattern (`uuuu-MM-dd`, `MM-dd-uuuu`, `M-d-u`, `M-u`) only had a leading `\b`, so nothing stopped a match from consuming a short prefix of a longer digit-and-delimiter token and silently ignoring the rest.

## Root cause

Two related failure modes, both reproduced from docket-number-style text:

- **A digit block matches fewer digits than are present.** `"Case No. 12-12110 K"` matched only `"12-1211"` via the `M-u` (month-year) pattern. Nothing after the year block forced the engine to backtrack into a shorter alternative that would leave the final `"0"` unconsumed, the same class of bug as #335.
- **A match stops at a delimiter and ignores that the same delimiter continues into more digits.** `"Case 1-20-01023-MJK"` matched only `"1-20"` via the same `M-u` pattern, because the pattern had no way to know `"-01023"` right after it is a continuation of the same token rather than unrelated trailing text — a different manifestation of the same underlying problem as #336.

## Fix

Extended the trailing assertion from `(?!\d)` to `(?!\d)(?!DELIMITER\d)`, built once per delimiter as `noMoreDigits` and appended to all four numeric templates:

```java
final String noMoreDigits = "(?!\d)(?!" + d + "\d)";
```

- `(?!\d)` rejects continuing into a bare digit (fixes the truncation case).
- `(?!` + delimiter + `\d)` rejects continuing into "the same delimiter followed by a digit" (fixes the delimiter-chain case).

Together they cover both ways a match can stop short of the full token, without requiring the match to know how long the real token is ahead of time.

## Testing

- `filterDate38` previously asserted the truncated `"12-1211"` match as the expected/correct result — that was the bug being codified as a passing test. Updated it to expect no spans, which now matches what `filterDate39` (same input, `onlyValidDates=true`) already expected via the separate `SpanValidator` path — both configurations now agree.
- Added `filterDate38b` covering the second repro (`"Case 1-20-01023-MJK"`, `onlyValidDates=false`), not previously covered.
- `mvn -Dtest=DateFilterTest test`: 56 tests, only the pre-existing, unrelated `filterDate34` fails (flaky relative-date assertion, fails identically on `main` without this change).
- Full suite (`mvn test`, JDK 25, Windows): 2043 tests, same baseline 2 failures / 1 error as `main` without this change (`filterDate34`, `EndToEndWithIncrementalRedactionsTest.endToEndWithSplits`, `PdfFilterServiceTest.testApply1` — the last a Windows-path issue unrelated to dates).

## Note on issue #340

I looked at #340 (`"91-100%"` matching as a date) while investigating this family of bugs, but I don't think it's a regex bug the way #335/#336/#341 are. `filterDate35` already covers this exact input with `onlyValidDates=true` and asserts 0 spans — passing today, because `DateSpanValidator` rejects month `91`. With `onlyValidDates=false` (the default), `filterDate2` shows the project's existing convention is to match by shape only regardless of calendar validity (`"13-06-31"` matches even though month 13 is invalid) — so a regex-level fix for #340 specifically excluding `%` would cut against that existing default-mode convention rather than complete it. Flagging this here in case it's useful; happy to be told otherwise.