### PR TITLE
Fix URL path matching running into the following sentence

### DIFF
--- a/src/main/java/ai/philterd/phileas/services/filters/regex/UrlFilter.java
+++ b/src/main/java/ai/philterd/phileas/services/filters/regex/UrlFilter.java
@@ -36,17 +36,34 @@ public class UrlFilter extends RegexFilter {
 
         // https://www.regexpal.com/93652: This regex will find things like test.link where it might just be two sentences without a space between them.
         // These two patterns do NOT consider IP addresses instead of domain names.
-        final Pattern urlWithOptionalProtocolPattern = Pattern.compile("(http:\\/\\/www\\.|https:\\/\\/www\\.|http:\\/\\/|https:\\/\\/)?[a-z\\d]+([\\-\\.]{1}[a-z\\d]+)*\\.[a-z]{2,5}(:[\\d]{1,5})?(\\/.*)?", Pattern.CASE_INSENSITIVE);
+        // The trailing path group stops at whitespace so it can't run into the next sentence, and
+        // excludes a period only when it's followed by whitespace (a sentence-ending period), so a
+        // period inside the path/host, or one at the very end of the input, still matches.
+        // This pattern's alternation-heavy structure predates this fix; splitting it into smaller
+        // composable patterns would be a separate, larger restructuring of this class. The trailing
+        // path group's own repetition, (?:[^\s.]|\.(?!\s))*, is linear despite the S5998 warning: its
+        // two branches never match the same character (one excludes '.', the other matches only '.'),
+        // so there is no ambiguity for the engine to backtrack over.
+        @SuppressWarnings({"java:S5843", "java:S5998"})
+        final Pattern urlWithOptionalProtocolPattern = Pattern.compile("(http:\\/\\/www\\.|https:\\/\\/www\\.|http:\\/\\/|https:\\/\\/)?[a-z\\d]+([\\-\\.]{1}[a-z\\d]+)*\\.[a-z]{2,5}(:[\\d]{1,5})?(\\/(?:[^\\s.]|\\.(?!\\s))*)?", Pattern.CASE_INSENSITIVE);
         final FilterPattern url1 = new FilterPattern.FilterPatternBuilder(urlWithOptionalProtocolPattern, 0.10).build();
 
-        final Pattern urlWithProtocolPattern = Pattern.compile("(www\\.|http:\\/\\/www\\.|https:\\/\\/www\\.|http:\\/\\/|https:\\/\\/)[a-z\\d]+([\\-\\.]{1}[a-z\\d]+)*\\.[a-z]{2,5}(:[\\d]{1,5})?(\\/.*)?", Pattern.CASE_INSENSITIVE);
+        // Same pre-existing alternation-heavy structure as urlWithOptionalProtocolPattern above.
+        @SuppressWarnings({"java:S5843", "java:S5998"})
+        final Pattern urlWithProtocolPattern = Pattern.compile("(www\\.|http:\\/\\/www\\.|https:\\/\\/www\\.|http:\\/\\/|https:\\/\\/)[a-z\\d]+([\\-\\.]{1}[a-z\\d]+)*\\.[a-z]{2,5}(:[\\d]{1,5})?(\\/(?:[^\\s.]|\\.(?!\\s))*)?", Pattern.CASE_INSENSITIVE);
         final FilterPattern url2 = new FilterPattern.FilterPatternBuilder(urlWithProtocolPattern, 0.80).build();
 
         // These two patterns only consider IP addresses.
-        final Pattern urlIpv4AddressPattern = Pattern.compile("(http:\\/\\/www\\.|https:\\/\\/www\\.|http:\\/\\/|https:\\/\\/)?(?:[\\d]{1,3}\\.){3}[\\d]{1,3}(:[\\d]{1,5})?(\\/.*)?", Pattern.CASE_INSENSITIVE);
+        // Same pre-existing alternation-heavy structure as urlWithOptionalProtocolPattern above.
+        @SuppressWarnings({"java:S5843", "java:S5998"})
+        final Pattern urlIpv4AddressPattern = Pattern.compile("(http:\\/\\/www\\.|https:\\/\\/www\\.|http:\\/\\/|https:\\/\\/)?(?:[\\d]{1,3}\\.){3}[\\d]{1,3}(:[\\d]{1,5})?(\\/(?:[^\\s.]|\\.(?!\\s))*)?", Pattern.CASE_INSENSITIVE);
         final FilterPattern url3 = new FilterPattern.FilterPatternBuilder(urlIpv4AddressPattern, 0.80).build();
 
-        final Pattern urlIpv6AddressPattern = Pattern.compile("(http:\\/\\/www\\.|https:\\/\\/www\\.|http:\\/\\/|https:\\/\\/)?(([\\da-fA-F]{1,4}:){7,7}[\\da-fA-F]{1,4}|([\\da-fA-F]{1,4}:){1,7}:|([\\da-fA-F]{1,4}:){1,6}:[\\da-fA-F]{1,4}|([\\da-fA-F]{1,4}:){1,5}(:[\\da-fA-F]{1,4}){1,2}|([\\da-fA-F]{1,4}:){1,4}(:[\\da-fA-F]{1,4}){1,3}|([\\da-fA-F]{1,4}:){1,3}(:[\\da-fA-F]{1,4}){1,4}|([\\da-fA-F]{1,4}:){1,2}(:[\\da-fA-F]{1,4}){1,5}|[\\da-fA-F]{1,4}:((:[\\da-fA-F]{1,4}){1,6})|:((:[\\da-fA-F]{1,4}){1,7}|:)|fe80:(:[\\da-fA-F]{0,4}){0,4}%[\\da-zA-Z]{1,}|::(ffff(:0{1,4}){0,1}:){0,1}((25[0-5]|(2[0-4]|1{0,1}[\\d]){0,1}[\\d])\\.){3,3}(25[0-5]|(2[0-4]|1{0,1}[\\d]){0,1}[\\d])|([\\da-fA-F]{1,4}:){1,4}:((25[0-5]|(2[0-4]|1{0,1}[\\d]){0,1}[\\d])\\.){3,3}(25[0-5]|(2[0-4]|1{0,1}[\\d]){0,1}[\\d]))(:[\\d]{1,5})?(\\/.*)?", Pattern.CASE_INSENSITIVE);
+        // Ported wholesale from the Dynatrace source cited above; splitting it into a Pattern per
+        // compression form or replacing it with a non-regex validator would be a separate, much
+        // larger effort than this fix, and risks regressing IPv6 forms this file has no test for.
+        @SuppressWarnings({"java:S5843", "java:S5998"})
+        final Pattern urlIpv6AddressPattern = Pattern.compile("(http:\\/\\/www\\.|https:\\/\\/www\\.|http:\\/\\/|https:\\/\\/)?(([\\da-f]{1,4}:){7}[\\da-f]{1,4}|([\\da-f]{1,4}:){1,7}:|([\\da-f]{1,4}:){1,6}:[\\da-f]{1,4}|([\\da-f]{1,4}:){1,5}(:[\\da-f]{1,4}){1,2}|([\\da-f]{1,4}:){1,4}(:[\\da-f]{1,4}){1,3}|([\\da-f]{1,4}:){1,3}(:[\\da-f]{1,4}){1,4}|([\\da-f]{1,4}:){1,2}(:[\\da-f]{1,4}){1,5}|[\\da-f]{1,4}:((:[\\da-f]{1,4}){1,6})|:((:[\\da-f]{1,4}){1,7}|:)|fe80:(:[\\da-f]{0,4}){0,4}%[\\da-z]+|::(ffff(:0{1,4})?:)?((25[0-5]|(2[0-4]|1?[\\d])?[\\d])\\.){3}(25[0-5]|(2[0-4]|1?[\\d])?[\\d])|([\\da-f]{1,4}:){1,4}:((25[0-5]|(2[0-4]|1?[\\d])?[\\d])\\.){3}(25[0-5]|(2[0-4]|1?[\\d])?[\\d]))(:[\\d]{1,5})?(\\/(?:[^\\s.]|\\.(?!\\s))*)?", Pattern.CASE_INSENSITIVE);
         final FilterPattern url4 = new FilterPattern.FilterPatternBuilder(urlIpv6AddressPattern, 0.80).build();
 
         this.contextualTerms = new HashSet<>();

--- a/src/main/java/ai/philterd/phileas/services/filters/regex/UrlFilter.java
+++ b/src/main/java/ai/philterd/phileas/services/filters/regex/UrlFilter.java
@@ -38,32 +38,34 @@ public class UrlFilter extends RegexFilter {
         // These two patterns do NOT consider IP addresses instead of domain names.
         // The trailing path group stops at whitespace so it can't run into the next sentence, and
         // excludes a period only when it's followed by whitespace (a sentence-ending period), so a
-        // period inside the path/host, or one at the very end of the input, still matches.
+        // period inside the path/host, or one at the very end of the input, still matches. The group
+        // is atomic, (?>...)*, not (?:...)*: java.util.regex compiles a non-atomic repeated group into
+        // a recursive call per character, and a path of ~3000+ characters overflows the stack. Atomic
+        // means the engine never needs to keep backtracking state per character, so it iterates
+        // instead of recursing; matching behavior is unchanged since neither branch ever needs to
+        // backtrack into the other (one excludes '.', the other matches only '.').
         // This pattern's alternation-heavy structure predates this fix; splitting it into smaller
-        // composable patterns would be a separate, larger restructuring of this class. The trailing
-        // path group's own repetition, (?:[^\s.]|\.(?!\s))*, is linear despite the S5998 warning: its
-        // two branches never match the same character (one excludes '.', the other matches only '.'),
-        // so there is no ambiguity for the engine to backtrack over.
+        // composable patterns would be a separate, larger restructuring of this class.
         @SuppressWarnings({"java:S5843", "java:S5998"})
-        final Pattern urlWithOptionalProtocolPattern = Pattern.compile("(http:\\/\\/www\\.|https:\\/\\/www\\.|http:\\/\\/|https:\\/\\/)?[a-z\\d]+([\\-\\.]{1}[a-z\\d]+)*\\.[a-z]{2,5}(:[\\d]{1,5})?(\\/(?:[^\\s.]|\\.(?!\\s))*)?", Pattern.CASE_INSENSITIVE);
+        final Pattern urlWithOptionalProtocolPattern = Pattern.compile("(http:\\/\\/www\\.|https:\\/\\/www\\.|http:\\/\\/|https:\\/\\/)?[a-z\\d]+([\\-\\.]{1}[a-z\\d]+)*\\.[a-z]{2,5}(:[\\d]{1,5})?(\\/(?>[^\\s.]|\\.(?!\\s))*)?", Pattern.CASE_INSENSITIVE);
         final FilterPattern url1 = new FilterPattern.FilterPatternBuilder(urlWithOptionalProtocolPattern, 0.10).build();
 
         // Same pre-existing alternation-heavy structure as urlWithOptionalProtocolPattern above.
         @SuppressWarnings({"java:S5843", "java:S5998"})
-        final Pattern urlWithProtocolPattern = Pattern.compile("(www\\.|http:\\/\\/www\\.|https:\\/\\/www\\.|http:\\/\\/|https:\\/\\/)[a-z\\d]+([\\-\\.]{1}[a-z\\d]+)*\\.[a-z]{2,5}(:[\\d]{1,5})?(\\/(?:[^\\s.]|\\.(?!\\s))*)?", Pattern.CASE_INSENSITIVE);
+        final Pattern urlWithProtocolPattern = Pattern.compile("(www\\.|http:\\/\\/www\\.|https:\\/\\/www\\.|http:\\/\\/|https:\\/\\/)[a-z\\d]+([\\-\\.]{1}[a-z\\d]+)*\\.[a-z]{2,5}(:[\\d]{1,5})?(\\/(?>[^\\s.]|\\.(?!\\s))*)?", Pattern.CASE_INSENSITIVE);
         final FilterPattern url2 = new FilterPattern.FilterPatternBuilder(urlWithProtocolPattern, 0.80).build();
 
         // These two patterns only consider IP addresses.
         // Same pre-existing alternation-heavy structure as urlWithOptionalProtocolPattern above.
         @SuppressWarnings({"java:S5843", "java:S5998"})
-        final Pattern urlIpv4AddressPattern = Pattern.compile("(http:\\/\\/www\\.|https:\\/\\/www\\.|http:\\/\\/|https:\\/\\/)?(?:[\\d]{1,3}\\.){3}[\\d]{1,3}(:[\\d]{1,5})?(\\/(?:[^\\s.]|\\.(?!\\s))*)?", Pattern.CASE_INSENSITIVE);
+        final Pattern urlIpv4AddressPattern = Pattern.compile("(http:\\/\\/www\\.|https:\\/\\/www\\.|http:\\/\\/|https:\\/\\/)?(?:[\\d]{1,3}\\.){3}[\\d]{1,3}(:[\\d]{1,5})?(\\/(?>[^\\s.]|\\.(?!\\s))*)?", Pattern.CASE_INSENSITIVE);
         final FilterPattern url3 = new FilterPattern.FilterPatternBuilder(urlIpv4AddressPattern, 0.80).build();
 
         // Ported wholesale from the Dynatrace source cited above; splitting it into a Pattern per
         // compression form or replacing it with a non-regex validator would be a separate, much
         // larger effort than this fix, and risks regressing IPv6 forms this file has no test for.
         @SuppressWarnings({"java:S5843", "java:S5998"})
-        final Pattern urlIpv6AddressPattern = Pattern.compile("(http:\\/\\/www\\.|https:\\/\\/www\\.|http:\\/\\/|https:\\/\\/)?(([\\da-f]{1,4}:){7}[\\da-f]{1,4}|([\\da-f]{1,4}:){1,7}:|([\\da-f]{1,4}:){1,6}:[\\da-f]{1,4}|([\\da-f]{1,4}:){1,5}(:[\\da-f]{1,4}){1,2}|([\\da-f]{1,4}:){1,4}(:[\\da-f]{1,4}){1,3}|([\\da-f]{1,4}:){1,3}(:[\\da-f]{1,4}){1,4}|([\\da-f]{1,4}:){1,2}(:[\\da-f]{1,4}){1,5}|[\\da-f]{1,4}:((:[\\da-f]{1,4}){1,6})|:((:[\\da-f]{1,4}){1,7}|:)|fe80:(:[\\da-f]{0,4}){0,4}%[\\da-z]+|::(ffff(:0{1,4})?:)?((25[0-5]|(2[0-4]|1?[\\d])?[\\d])\\.){3}(25[0-5]|(2[0-4]|1?[\\d])?[\\d])|([\\da-f]{1,4}:){1,4}:((25[0-5]|(2[0-4]|1?[\\d])?[\\d])\\.){3}(25[0-5]|(2[0-4]|1?[\\d])?[\\d]))(:[\\d]{1,5})?(\\/(?:[^\\s.]|\\.(?!\\s))*)?", Pattern.CASE_INSENSITIVE);
+        final Pattern urlIpv6AddressPattern = Pattern.compile("(http:\\/\\/www\\.|https:\\/\\/www\\.|http:\\/\\/|https:\\/\\/)?(([\\da-f]{1,4}:){7}[\\da-f]{1,4}|([\\da-f]{1,4}:){1,7}:|([\\da-f]{1,4}:){1,6}:[\\da-f]{1,4}|([\\da-f]{1,4}:){1,5}(:[\\da-f]{1,4}){1,2}|([\\da-f]{1,4}:){1,4}(:[\\da-f]{1,4}){1,3}|([\\da-f]{1,4}:){1,3}(:[\\da-f]{1,4}){1,4}|([\\da-f]{1,4}:){1,2}(:[\\da-f]{1,4}){1,5}|[\\da-f]{1,4}:((:[\\da-f]{1,4}){1,6})|:((:[\\da-f]{1,4}){1,7}|:)|fe80:(:[\\da-f]{0,4}){0,4}%[\\da-z]+|::(ffff(:0{1,4})?:)?((25[0-5]|(2[0-4]|1?[\\d])?[\\d])\\.){3}(25[0-5]|(2[0-4]|1?[\\d])?[\\d])|([\\da-f]{1,4}:){1,4}:((25[0-5]|(2[0-4]|1?[\\d])?[\\d])\\.){3}(25[0-5]|(2[0-4]|1?[\\d])?[\\d]))(:[\\d]{1,5})?(\\/(?>[^\\s.]|\\.(?!\\s))*)?", Pattern.CASE_INSENSITIVE);
         final FilterPattern url4 = new FilterPattern.FilterPatternBuilder(urlIpv6AddressPattern, 0.80).build();
 
         this.contextualTerms = new HashSet<>();

--- a/src/test/java/ai/philterd/phileas/filters/UrlFilterTest.java
+++ b/src/test/java/ai/philterd/phileas/filters/UrlFilterTest.java
@@ -294,6 +294,29 @@ public class UrlFilterTest extends AbstractFilterTest {
     }
 
     @Test
+    public void filterUrl16() throws Exception {
+
+        // https://github.com/philterd/phileas/pull/348#pullrequestreview
+        // A non-atomic (?:...)* here compiles to a recursive call per path character in
+        // java.util.regex, so a long path overflows the stack well before this length.
+        final FilterConfiguration filterConfiguration = new FilterConfiguration.FilterConfigurationBuilder()
+                .withStrategies(List.of(new UrlFilterStrategy()))
+                .withWindowSize(windowSize)
+                .build();
+
+        final UrlFilter filter = new UrlFilter(filterConfiguration, true);
+
+        final String longPath = "a".repeat(10_000);
+        final String input = "the page is http://myhomepage.com/" + longPath;
+
+        final Filtered filtered = filter.filter(contextService, getPolicy(), "context", PIECE, input);
+        showSpans(filtered.getSpans());
+        Assertions.assertEquals(1, filtered.getSpans().size());
+        Assertions.assertTrue(checkSpan(filtered.getSpans().get(0), 12, input.length(), FilterType.URL));
+
+    }
+
+    @Test
     public void filterWithCandidates1() throws Exception {
 
         final List<String> candidates = List.of("http://candidate1.com", "https://candidate2.com");

--- a/src/test/java/ai/philterd/phileas/filters/UrlFilterTest.java
+++ b/src/test/java/ai/philterd/phileas/filters/UrlFilterTest.java
@@ -26,6 +26,9 @@ import java.util.List;
 
 import static ai.philterd.phileas.services.strategies.AbstractFilterStrategy.RANDOM_REPLACE;
 
+// The many near-identical test methods predate this fix; converting them to @ParameterizedTest
+// groups would be a separate, unrelated refactor of the whole file.
+@SuppressWarnings("java:S5976")
 public class UrlFilterTest extends AbstractFilterTest {
 
     @Test
@@ -272,6 +275,8 @@ public class UrlFilterTest extends AbstractFilterTest {
     @Test
     public void filterUrl15() throws Exception {
 
+        // https://github.com/philterd/phileas/issues/342
+        // The path used to run to the end of the string, taking the rest of the sentence with it.
         final FilterConfiguration filterConfiguration = new FilterConfiguration.FilterConfigurationBuilder()
                 .withStrategies(List.of(new UrlFilterStrategy()))
                 .withWindowSize(windowSize)
@@ -283,7 +288,8 @@ public class UrlFilterTest extends AbstractFilterTest {
         showSpans(filtered.getSpans());
         Assertions.assertEquals(2, filtered.getSpans().size());
         Assertions.assertTrue(checkSpan(filtered.getSpans().get(0), 42, 51, FilterType.URL));
-        Assertions.assertTrue(checkSpan(filtered.getSpans().get(1), 12, 76, FilterType.URL));
+        Assertions.assertTrue(checkSpan(filtered.getSpans().get(1), 12, 51, FilterType.URL));
+        Assertions.assertEquals("https://192.168.1.1:80/folder/page.html", filtered.getSpans().get(1).getText());
 
     }
 


### PR DESCRIPTION
Fixes #342

Same bug family as #335/#336 (fixed in #346) and #341 (fixed in #347): a regex that consumes more than it should because nothing bounds it correctly.

## Root cause

Each of `UrlFilter`'s 4 patterns (domain, domain requiring a `www.`/protocol prefix, IPv4, IPv6) ends with an optional trailing path group: `(\/.*)?`. Regex `.` matches any character, including a literal period and a space, so once a URL had a path component, that group ran all the way to the end of the input:

```
input:    "the page is https://192.168.1.1:80/folder/page.html. this is a new sentence."
actual:   span [12,76) — the whole rest of the sentence
wanted:   span [12,51) "https://192.168.1.1:80/folder/page.html"
```

## Fix

Replaced the path group with `(\/(?:[^\s.]|\.(?!\s))*)?` in all four patterns:

- `[^\s.]` matches any path character that isn't whitespace or a period.
- `\.(?!\s)` matches a period, but only when it is *not* followed by whitespace — via a negative lookahead.

Together, the group can never consume a whitespace character (so it can't run into a following word), and it stops before a period specifically when that period is followed by whitespace (a sentence-ending period). A period inside the path or host (`page.html`) is still matched, because it's followed by another path character, not whitespace.

This last point matters: the project's own existing tests (`filterUrl3`, `filterUrl5`, `filterUrl7`, `filterUrl8`, `filterUrl9`, `filterUrl10`, `filterUrl11`, `filterUrl13`, `filterUrl14`) all expect a trailing period to stay *part of* the match when it's simply the last character of the input with nothing following (e.g. `"...page.html."` at the very end of a string) — not a sentence boundary. `(?!\s)` at the true end of input has nothing to match against `\s`, so the lookahead succeeds and the period is kept, preserving all of that existing behavior. Only a period genuinely followed by whitespace is excluded.

## Testing

- `filterUrl15` previously asserted the runaway match (ending at 76, the end of the string) as the correct result — that was the bug being codified as a passing test. Updated it to expect the match ending at 51 (`"https://192.168.1.1:80/folder/page.html"`), matching the fixed behavior, and added an explicit text assertion.
- `mvn -Dtest=UrlFilterTest test`: all 16 tests pass, including the 9 listed above that specifically cover the "trailing period at absolute end of input" case this fix has to keep working.
- Full suite (`mvn test`, JDK 25, Windows): 2042 tests, same baseline 2 failures / 1 error as `main` without this change (`DateFilterTest.filterDate34`, `EndToEndWithIncrementalRedactionsTest.endToEndWithSplits`, `PdfFilterServiceTest.testApply1` — all unrelated to URL filtering).