### PR TITLE
Fix IPv6 addresses matching only up to the :: compression

### DIFF
--- a/src/main/java/ai/philterd/phileas/services/filters/regex/UrlFilter.java
+++ b/src/main/java/ai/philterd/phileas/services/filters/regex/UrlFilter.java
@@ -63,9 +63,33 @@ public class UrlFilter extends RegexFilter {
 
         // Ported wholesale from the Dynatrace source cited above; splitting it into a Pattern per
         // compression form or replacing it with a non-regex validator would be a separate, much
-        // larger effort than this fix, and risks regressing IPv6 forms this file has no test for.
+        // larger effort than this fix.
         @SuppressWarnings({"java:S5843", "java:S5998"})
-        final Pattern urlIpv6AddressPattern = Pattern.compile("(http:\\/\\/www\\.|https:\\/\\/www\\.|http:\\/\\/|https:\\/\\/)?(([\\da-f]{1,4}:){7}[\\da-f]{1,4}|([\\da-f]{1,4}:){1,7}:|([\\da-f]{1,4}:){1,6}:[\\da-f]{1,4}|([\\da-f]{1,4}:){1,5}(:[\\da-f]{1,4}){1,2}|([\\da-f]{1,4}:){1,4}(:[\\da-f]{1,4}){1,3}|([\\da-f]{1,4}:){1,3}(:[\\da-f]{1,4}){1,4}|([\\da-f]{1,4}:){1,2}(:[\\da-f]{1,4}){1,5}|[\\da-f]{1,4}:((:[\\da-f]{1,4}){1,6})|:((:[\\da-f]{1,4}){1,7}|:)|fe80:(:[\\da-f]{0,4}){0,4}%[\\da-z]+|::(ffff(:0{1,4})?:)?((25[0-5]|(2[0-4]|1?[\\d])?[\\d])\\.){3}(25[0-5]|(2[0-4]|1?[\\d])?[\\d])|([\\da-f]{1,4}:){1,4}:((25[0-5]|(2[0-4]|1?[\\d])?[\\d])\\.){3}(25[0-5]|(2[0-4]|1?[\\d])?[\\d]))(:[\\d]{1,5})?(\\/(?>[^\\s.]|\\.(?!\\s))*)?", Pattern.CASE_INSENSITIVE);
+        final String ipv6Alternatives = "(([\\da-f]{1,4}:){7}[\\da-f]{1,4}|([\\da-f]{1,4}:){1,7}:|([\\da-f]{1,4}:){1,6}:[\\da-f]{1,4}|([\\da-f]{1,4}:){1,5}(:[\\da-f]{1,4}){1,2}|([\\da-f]{1,4}:){1,4}(:[\\da-f]{1,4}){1,3}|([\\da-f]{1,4}:){1,3}(:[\\da-f]{1,4}){1,4}|([\\da-f]{1,4}:){1,2}(:[\\da-f]{1,4}){1,5}|[\\da-f]{1,4}:((:[\\da-f]{1,4}){1,6})|:((:[\\da-f]{1,4}){1,7}|:)|fe80:(:[\\da-f]{0,4}){0,4}%[\\da-z]+|::(ffff(:0{1,4})?:)?((25[0-5]|(2[0-4]|1?[\\d])?[\\d])\\.){3}(25[0-5]|(2[0-4]|1?[\\d])?[\\d])|([\\da-f]{1,4}:){1,4}:((25[0-5]|(2[0-4]|1?[\\d])?[\\d])\\.){3}(25[0-5]|(2[0-4]|1?[\\d])?[\\d]))";
+
+        // The alternation above is ordered and java.util.regex takes the first alternative that
+        // matches, not the longest, so a compressed address was matched only as far as its "::" and
+        // the rest of it stayed in the document. See issue #351. This boundary rejects a match that
+        // stopped inside an address, which makes the engine backtrack into an alternative that
+        // consumes all of it:
+        //   (?![\da-f])   not a bare hex digit,     e.g. "FE80::" out of "FE80::1"
+        //   (?!:[\da-f])  not a further hextet,     e.g. "2001:db8:85a3::" out of "...::8a2e:370:7334"
+        //   (?!\.\d)      not a further IPv4 octet, e.g. "::ffff:192" out of "::ffff:192.0.2.128"
+        // A period that is not followed by a digit still ends the match, so the trailing period of
+        // "the host is fe80::1." is left out of the address rather than blocking the match.
+        final String ipv6Boundary = "(?![\\da-f])(?!:[\\da-f])(?!\\.\\d)";
+
+        // An optional zone identifier, e.g. "fe80::1%eth0", or "%25eth0" percent-encoded for a URI.
+        // Without this an address carrying a zone matched nothing at all, because the boundary above
+        // rejects every alternative that stops at the "%".
+        final String ipv6Zone = "(?:%[\\da-z]+)?";
+
+        final String ipv6Address = ipv6Alternatives + ipv6Zone + ipv6Boundary;
+
+        // Only a bracketed host can carry a port: an unbracketed trailing ":8080" cannot be told
+        // apart from another hextet, and is treated as part of the address.
+        @SuppressWarnings({"java:S5843", "java:S5998"})
+        final Pattern urlIpv6AddressPattern = Pattern.compile("(http:\\/\\/www\\.|https:\\/\\/www\\.|http:\\/\\/|https:\\/\\/)?(?:\\[" + ipv6Address + "\\](:[\\d]{1,5})?|" + ipv6Address + ")(\\/(?>[^\\s.]|\\.(?!\\s))*)?", Pattern.CASE_INSENSITIVE);
         final FilterPattern url4 = new FilterPattern.FilterPatternBuilder(urlIpv6AddressPattern, 0.80).build();
 
         this.contextualTerms = new HashSet<>();

--- a/src/test/java/ai/philterd/phileas/filters/UrlFilterTest.java
+++ b/src/test/java/ai/philterd/phileas/filters/UrlFilterTest.java
@@ -317,6 +317,146 @@ public class UrlFilterTest extends AbstractFilterTest {
     }
 
     @Test
+    public void filterUrl17() throws Exception {
+
+        // https://github.com/philterd/phileas/issues/351
+        // A compressed address used to match only as far as its "::", leaving the rest in the clear.
+        final FilterConfiguration filterConfiguration = new FilterConfiguration.FilterConfigurationBuilder()
+                .withStrategies(List.of(new UrlFilterStrategy()))
+                .withWindowSize(windowSize)
+                .build();
+
+        final UrlFilter filter = new UrlFilter(filterConfiguration, false);
+
+        final Filtered filtered = filter.filter(contextService, getPolicy(), "context", PIECE, "host FE80::1");
+        showSpans(filtered.getSpans());
+        Assertions.assertEquals(1, filtered.getSpans().size());
+        Assertions.assertTrue(checkSpan(filtered.getSpans().get(0), 5, 12, FilterType.URL));
+        Assertions.assertEquals("FE80::1", filtered.getSpans().get(0).getText());
+
+    }
+
+    @Test
+    public void filterUrl18() throws Exception {
+
+        // https://github.com/philterd/phileas/issues/351
+        final FilterConfiguration filterConfiguration = new FilterConfiguration.FilterConfigurationBuilder()
+                .withStrategies(List.of(new UrlFilterStrategy()))
+                .withWindowSize(windowSize)
+                .build();
+
+        final UrlFilter filter = new UrlFilter(filterConfiguration, false);
+
+        final Filtered filtered = filter.filter(contextService, getPolicy(), "context", PIECE, "host 2001:db8:85a3::8a2e:370:7334");
+        showSpans(filtered.getSpans());
+        Assertions.assertEquals(1, filtered.getSpans().size());
+        Assertions.assertTrue(checkSpan(filtered.getSpans().get(0), 5, 33, FilterType.URL));
+        Assertions.assertEquals("2001:db8:85a3::8a2e:370:7334", filtered.getSpans().get(0).getText());
+
+    }
+
+    @Test
+    public void filterUrl19() throws Exception {
+
+        // https://github.com/philterd/phileas/issues/351
+        // An IPv4-mapped address. The embedded IPv4 address is also matched by the IPv4 pattern, so
+        // the whole address and the trailing dotted quad are both spans.
+        final FilterConfiguration filterConfiguration = new FilterConfiguration.FilterConfigurationBuilder()
+                .withStrategies(List.of(new UrlFilterStrategy()))
+                .withWindowSize(windowSize)
+                .build();
+
+        final UrlFilter filter = new UrlFilter(filterConfiguration, false);
+
+        final Filtered filtered = filter.filter(contextService, getPolicy(), "context", PIECE, "host ::ffff:192.0.2.128");
+        showSpans(filtered.getSpans());
+        Assertions.assertEquals(2, filtered.getSpans().size());
+        Assertions.assertEquals("192.0.2.128", filtered.getSpans().get(0).getText());
+        Assertions.assertTrue(checkSpan(filtered.getSpans().get(1), 5, 23, FilterType.URL));
+        Assertions.assertEquals("::ffff:192.0.2.128", filtered.getSpans().get(1).getText());
+
+    }
+
+    @Test
+    public void filterUrl20() throws Exception {
+
+        // https://github.com/philterd/phileas/issues/351
+        // A zone identifier. Without the zone in the pattern the boundary rejects every alternative
+        // that stops at the "%", so the address matched nothing at all.
+        final FilterConfiguration filterConfiguration = new FilterConfiguration.FilterConfigurationBuilder()
+                .withStrategies(List.of(new UrlFilterStrategy()))
+                .withWindowSize(windowSize)
+                .build();
+
+        final UrlFilter filter = new UrlFilter(filterConfiguration, false);
+
+        final Filtered filtered = filter.filter(contextService, getPolicy(), "context", PIECE, "host fe80::1%eth0");
+        showSpans(filtered.getSpans());
+        Assertions.assertEquals(1, filtered.getSpans().size());
+        Assertions.assertTrue(checkSpan(filtered.getSpans().get(0), 5, 17, FilterType.URL));
+        Assertions.assertEquals("fe80::1%eth0", filtered.getSpans().get(0).getText());
+
+    }
+
+    @Test
+    public void filterUrl21() throws Exception {
+
+        // https://github.com/philterd/phileas/issues/351
+        // A bracketed host, which is the only form that can carry a port.
+        final FilterConfiguration filterConfiguration = new FilterConfiguration.FilterConfigurationBuilder()
+                .withStrategies(List.of(new UrlFilterStrategy()))
+                .withWindowSize(windowSize)
+                .build();
+
+        final UrlFilter filter = new UrlFilter(filterConfiguration, false);
+
+        final Filtered filtered = filter.filter(contextService, getPolicy(), "context", PIECE, "http://[2001:db8::1]:8080/x");
+        showSpans(filtered.getSpans());
+        Assertions.assertEquals(1, filtered.getSpans().size());
+        Assertions.assertTrue(checkSpan(filtered.getSpans().get(0), 0, 27, FilterType.URL));
+        Assertions.assertEquals("http://[2001:db8::1]:8080/x", filtered.getSpans().get(0).getText());
+
+    }
+
+    @Test
+    public void filterUrl22() throws Exception {
+
+        // https://github.com/philterd/phileas/issues/351
+        // Colon-separated text that is not an address stays unmatched.
+        final FilterConfiguration filterConfiguration = new FilterConfiguration.FilterConfigurationBuilder()
+                .withStrategies(List.of(new UrlFilterStrategy()))
+                .withWindowSize(windowSize)
+                .build();
+
+        final UrlFilter filter = new UrlFilter(filterConfiguration, false);
+
+        Assertions.assertEquals(0, filter.filter(contextService, getPolicy(), "context", PIECE, "the time is 12:30 and the ratio is 1:2").getSpans().size());
+        Assertions.assertEquals(0, filter.filter(contextService, getPolicy(), "context", PIECE, "see chapter 3:16 for details").getSpans().size());
+        Assertions.assertEquals(0, filter.filter(contextService, getPolicy(), "context", PIECE, "the mac address is 00:1b:44:11:3a:b7").getSpans().size());
+
+    }
+
+    @Test
+    public void filterUrl23() throws Exception {
+
+        // https://github.com/philterd/phileas/issues/351
+        // The fully expanded form, on its own rather than inside a URL as in filterUrl13 and 14.
+        final FilterConfiguration filterConfiguration = new FilterConfiguration.FilterConfigurationBuilder()
+                .withStrategies(List.of(new UrlFilterStrategy()))
+                .withWindowSize(windowSize)
+                .build();
+
+        final UrlFilter filter = new UrlFilter(filterConfiguration, false);
+
+        final Filtered filtered = filter.filter(contextService, getPolicy(), "context", PIECE, "host 2001:0db8:85a3:0000:0000:8a2e:0370:7334");
+        showSpans(filtered.getSpans());
+        Assertions.assertEquals(1, filtered.getSpans().size());
+        Assertions.assertTrue(checkSpan(filtered.getSpans().get(0), 5, 44, FilterType.URL));
+        Assertions.assertEquals("2001:0db8:85a3:0000:0000:8a2e:0370:7334", filtered.getSpans().get(0).getText());
+
+    }
+
+    @Test
     public void filterWithCandidates1() throws Exception {
 
         final List<String> candidates = List.of("http://candidate1.com", "https://candidate2.com");


### PR DESCRIPTION
### Description
Fix IPv6 addresses matching only up to the :: compression.

### Issues Resolved
Closes #351

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
