### PR TITLE
Keep both dates in a range written without spaces

### DIFF
--- a/src/main/java/ai/philterd/phileas/services/filters/regex/DateFilter.java
+++ b/src/main/java/ai/philterd/phileas/services/filters/regex/DateFilter.java
@@ -143,15 +143,20 @@ public class DateFilter extends RegexFilter {
             // human-readable date format.
             final String d = Pattern.quote(delimiter);
 
-            // Neither a bare digit nor "delimiter + digit" may follow a match: the former blocks
-            // matching a short prefix of a longer number (e.g. "255" as "25"), the latter blocks
-            // matching a short prefix of a longer delimited chain (e.g. "1-20" out of "1-20-01023").
-            // The space delimiter is exempt from the second lookahead: space also separates ordinary
-            // words, so "space + digit" after a space-delimited date (e.g. "12 25 2020 4 days") is
-            // normal surrounding text, not a continuation of the same chain.
+            // Any complete numeric date. The month-and-year shape is left out for "." for the same
+            // reason it is not generated there: it would make a decimal such as 3.14 a date.
+            final String anyNumericDate = "(?:\\d{4}" + d + "\\d{2}" + d + "\\d{2}"
+                    + "|\\d{1,2}" + d + "\\d{1,2}" + d + "\\d{2,4}"
+                    + (".".equals(delimiter) ? "" : "|\\d{1,2}" + d + "\\d{2,4}") + ")";
+
+            // A match may not stop partway through a longer number ("25" out of "255") or a longer
+            // delimited chain ("1-20" out of "1-20-01023"). A continuation is allowed only when all
+            // that is left decomposes into dates, so "2024-06-01-2024-06-30" keeps both. Unbounded,
+            // the repetition overflows the stack on a long chain. Space is exempt: it separates
+            // ordinary words too. See issues #341 and #353.
             final String noMoreDigits = " ".equals(delimiter)
                     ? "(?!\\d)"
-                    : "(?!\\d)(?!" + d + "\\d)";
+                    : "(?!\\d)(?:(?!" + d + "\\d)|(?=(?:" + d + anyNumericDate + "){1,8}(?!\\d)(?!" + d + "\\d)))";
 
             // Make a filter pattern for each pattern with each delimiter. The numeric day/month/year
             // patterns carry a month-first format; day-first dates (e.g. 25/12/1980) that month-first

--- a/src/test/java/ai/philterd/phileas/filters/DateFilterTest.java
+++ b/src/test/java/ai/philterd/phileas/filters/DateFilterTest.java
@@ -536,6 +536,122 @@ public class DateFilterTest extends AbstractFilterTest {
     }
 
     @Test
+    public void filterDate38e() throws Exception {
+
+        // https://github.com/philterd/phileas/issues/353
+        // A range without spaces: the #341 boundary dropped every date but the last.
+
+        final DateFilter filter = new DateFilter(buildFilterConfiguration(), false, DateSpanValidator.getInstance());
+
+        final Filtered filtered = filter.filter(contextService, getPolicy(), "context", PIECE, "seen 2024-06-01-2024-06-30");
+
+        showSpans(filtered.getSpans());
+
+        Assertions.assertEquals(2, filtered.getSpans().size());
+        Assertions.assertEquals("2024-06-01", filtered.getSpans().get(0).getText());
+        Assertions.assertEquals(5, filtered.getSpans().get(0).getCharacterStart());
+        Assertions.assertEquals(15, filtered.getSpans().get(0).getCharacterEnd());
+        Assertions.assertEquals("2024-06-30", filtered.getSpans().get(1).getText());
+        Assertions.assertEquals(16, filtered.getSpans().get(1).getCharacterStart());
+        Assertions.assertEquals(26, filtered.getSpans().get(1).getCharacterEnd());
+
+    }
+
+    @Test
+    public void filterDate38f() throws Exception {
+
+        // https://github.com/philterd/phileas/issues/353
+
+        final DateFilter filter = new DateFilter(buildFilterConfiguration(), false, DateSpanValidator.getInstance());
+
+        final Filtered filtered = filter.filter(contextService, getPolicy(), "context", PIECE, "log 2024-06-01-2024-06-30-2024-07-01");
+
+        showSpans(filtered.getSpans());
+
+        Assertions.assertEquals(3, filtered.getSpans().size());
+        Assertions.assertEquals("2024-06-01", filtered.getSpans().get(0).getText());
+        Assertions.assertEquals(4, filtered.getSpans().get(0).getCharacterStart());
+        Assertions.assertEquals(14, filtered.getSpans().get(0).getCharacterEnd());
+        Assertions.assertEquals("2024-06-30", filtered.getSpans().get(1).getText());
+        Assertions.assertEquals(15, filtered.getSpans().get(1).getCharacterStart());
+        Assertions.assertEquals(25, filtered.getSpans().get(1).getCharacterEnd());
+        Assertions.assertEquals("2024-07-01", filtered.getSpans().get(2).getText());
+        Assertions.assertEquals(26, filtered.getSpans().get(2).getCharacterStart());
+        Assertions.assertEquals(36, filtered.getSpans().get(2).getCharacterEnd());
+
+    }
+
+    @Test
+    public void filterDate38g() throws Exception {
+
+        // https://github.com/philterd/phileas/issues/353
+        // Month-and-year dates chained the same way.
+
+        final DateFilter filter = new DateFilter(buildFilterConfiguration(), false, DateSpanValidator.getInstance());
+
+        final Filtered filtered = filter.filter(contextService, getPolicy(), "context", PIECE, "ref 12-2020-12-2021");
+
+        showSpans(filtered.getSpans());
+
+        Assertions.assertEquals(2, filtered.getSpans().size());
+        Assertions.assertEquals("12-2020", filtered.getSpans().get(0).getText());
+        Assertions.assertEquals(4, filtered.getSpans().get(0).getCharacterStart());
+        Assertions.assertEquals(11, filtered.getSpans().get(0).getCharacterEnd());
+        Assertions.assertEquals("12-2021", filtered.getSpans().get(1).getText());
+        Assertions.assertEquals(12, filtered.getSpans().get(1).getCharacterStart());
+        Assertions.assertEquals(19, filtered.getSpans().get(1).getCharacterEnd());
+
+    }
+
+    @Test
+    public void filterDate38h() throws Exception {
+
+        // https://github.com/philterd/phileas/issues/353
+        // A phone number is still not a date.
+
+        final DateFilter filter = new DateFilter(buildFilterConfiguration(), false, DateSpanValidator.getInstance());
+
+        final Filtered filtered = filter.filter(contextService, getPolicy(), "context", PIECE, "phone 555-123-4567");
+
+        showSpans(filtered.getSpans());
+
+        Assertions.assertEquals(0, filtered.getSpans().size());
+
+    }
+
+    @Test
+    public void filterDate38i() throws Exception {
+
+        // https://github.com/philterd/phileas/issues/353
+        // The tail starts date-shaped ("1-20") but does not decompose into dates.
+
+        final DateFilter filter = new DateFilter(buildFilterConfiguration(), false, DateSpanValidator.getInstance());
+
+        final Filtered filtered = filter.filter(contextService, getPolicy(), "context", PIECE, "acct 12-2020-1-20-01023");
+
+        showSpans(filtered.getSpans());
+
+        Assertions.assertEquals(0, filtered.getSpans().size());
+
+    }
+
+    @Test
+    public void filterDate38j() throws Exception {
+
+        // https://github.com/philterd/phileas/issues/353
+        // ".3.14" is not a date for the "." delimiter, so it does not make this one either.
+
+        final DateFilter filter = new DateFilter(buildFilterConfiguration(), false, DateSpanValidator.getInstance());
+
+        final Filtered filtered = filter.filter(contextService, getPolicy(), "context", PIECE, "x 25.12.1980.3.14");
+
+        showSpans(filtered.getSpans());
+
+        Assertions.assertEquals(0, filtered.getSpans().size());
+
+    }
+
+    @Test
     public void filterDate39() throws Exception {
 
         final DateFilter filter = new DateFilter(buildFilterConfiguration(), true, DateSpanValidator.getInstance());


### PR DESCRIPTION
### Description
Keep both dates in a range written without spaces.

### Issues Resolved
Closes #353 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
