### PR TITLE
Round-trip the policy metadata section

### DIFF
--- a/src/main/java/ai/philterd/phileas/policy/Policy.java
+++ b/src/main/java/ai/philterd/phileas/policy/Policy.java
@@ -19,6 +19,7 @@ import ai.philterd.phisql.CompileResult;
 import ai.philterd.phisql.Compiler;
 import ai.philterd.phisql.PhiSQL;
 import com.google.gson.Gson;
+import com.google.gson.JsonObject;
 import com.google.gson.annotations.Expose;
 import com.google.gson.annotations.SerializedName;
 import org.apache.commons.lang3.builder.EqualsBuilder;
@@ -56,6 +57,13 @@ public class Policy {
         return new Gson().fromJson(result.toJsonString(), Policy.class);
 
     }
+
+    // Descriptive information carried with the policy. Held as raw JSON so keys the
+    // engine does not know about survive a load-and-save round trip. Never read during
+    // filtering.
+    @SerializedName("metadata")
+    @Expose
+    private JsonObject metadata;
 
     @SerializedName("config")
     @Expose
@@ -171,6 +179,14 @@ public class Policy {
 
     public void setIgnoredPatterns(List<IgnoredPattern> ignoredPatterns) {
         this.ignoredPatterns = ignoredPatterns;
+    }
+
+    public JsonObject getMetadata() {
+        return metadata;
+    }
+
+    public void setMetadata(JsonObject metadata) {
+        this.metadata = metadata;
     }
 
     public Config getConfig() {

--- a/src/test/java/ai/philterd/phileas/policy/PolicyTest.java
+++ b/src/test/java/ai/philterd/phileas/policy/PolicyTest.java
@@ -59,6 +59,8 @@ import ai.philterd.phileas.services.strategies.rules.UrlFilterStrategy;
 import ai.philterd.phileas.services.strategies.rules.VinFilterStrategy;
 import ai.philterd.phileas.services.strategies.rules.ZipCodeFilterStrategy;
 import com.google.gson.Gson;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
 import com.google.gson.GsonBuilder;
 import ai.philterd.phileas.utils.CollectionUtils;
 import org.junit.jupiter.api.Assertions;
@@ -79,6 +81,45 @@ public class PolicyTest {
         System.out.println(json);
 
         Assertions.assertNotNull(json);
+
+    }
+
+    @Test
+    public void metadataRoundTrips() {
+
+        // Keys beyond description are allowed by the schema, so they have to survive too.
+        final String json = """
+                {
+                  "metadata": {
+                    "description": "Client intake forms.",
+                    "author": "records team",
+                    "labels": ["intake", "pii"]
+                  },
+                  "identifiers": { "ssn": { "ssnFilterStrategies": [ { "strategy": "REDACT" } ] } }
+                }""";
+
+        final Gson gson = new Gson();
+        final Policy policy = gson.fromJson(json, Policy.class);
+
+        Assertions.assertEquals("Client intake forms.", policy.getMetadata().get("description").getAsString());
+        Assertions.assertEquals("records team", policy.getMetadata().get("author").getAsString());
+
+        // Re-serializing must not drop or alter any of it.
+        final JsonObject before = JsonParser.parseString(json).getAsJsonObject().getAsJsonObject("metadata");
+        final JsonObject after = JsonParser.parseString(gson.toJson(policy)).getAsJsonObject().getAsJsonObject("metadata");
+        Assertions.assertEquals(before, after);
+
+    }
+
+    @Test
+    public void policyWithoutMetadataSerializesWithoutIt() {
+
+        final Gson gson = new Gson();
+        final Policy policy = gson.fromJson("""
+                { "identifiers": { "ssn": { "ssnFilterStrategies": [ { "strategy": "REDACT" } ] } } }""", Policy.class);
+
+        Assertions.assertNull(policy.getMetadata());
+        Assertions.assertFalse(gson.toJson(policy).contains("metadata"));
 
     }
 


### PR DESCRIPTION
Schema 1.3.0 adds an optional top-level `metadata` object (philterd/phisql#39). Without a matching field on `Policy`, an engine that loads a policy and re-serializes it drops the section, which is the path Philter's API takes.

`metadata` is held as a `JsonObject` rather than a typed class so keys beyond `description` (author, labels, anything added later) survive the round trip. It is never read during filtering, and a policy without it still serializes without the key.

Verified: full suite passes (2132 tests).