### PR TITLE
Remove policy name from docs

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -4,6 +4,10 @@ Notable changes to Phileas, most recent first.
 
 Full changelogs for each release are available in the [GitHub releases](https://github.com/philterd/phileas/releases). Issues whose identifiers start with `PHL-` were previously tracked in Jira before the project's issues were managed in GitHub.
 
+## Version 4.4.0 - Unreleased
+
+* `Policy` now exposes the description held in `metadata.description` through `getDescription()` and `setDescription(String)`, so a caller no longer parses the raw metadata JSON. Setting a description on a policy that has no metadata creates the section, and clearing the only description removes it, so an empty `metadata` object is never serialized; any other metadata keys are left in place. A PhiSQL `DESCRIPTION` clause compiles to `metadata.description`, so a compiled policy carries its description here. (issue #375)
+
 ## Version 4.3.0 - September 3, 2026
 
 * The `ABBREVIATE` redaction strategy now reduces a detected value to the uppercase initials of its words (for example `john smith` becomes `JS`) for any filter type, matching the Python and .NET ports. Previously it produced initials only on the Ph-Eye NER path for `PER`-labeled entities, did not uppercase, and silently fell back to full redaction for the dictionary-based filters (surname, first name, and others). It is also honored as a `MAP_REPLACE` fallback strategy.
@@ -26,6 +30,7 @@ Full changelogs for each release are available in the [GitHub releases](https://
 * A filter strategy a filter does not implement is now logged at `WARN` when the policy is loaded, naming the strategy and the filter and listing what that filter accepts. The behavior is unchanged: the filter still falls back to `REDACT`, which fails closed, so existing policies keep working. Previously the fallback was silent at every log level, so a misspelled `CRYPTO_REPLACE` or `FPE_ENCRYPT_REPLACE` produced irreversible redaction with nothing to indicate it. An empty or blank strategy is treated the same way. The documentation now lists which strategies each filter accepts. (issue #344)
 * The zip-code filter now accepts `zipCodeFilterStrategies` in a policy, the plural form every other filter uses. Previously it read only the singular `zipCodeFilterStrategy`, so a policy following the convention (including the examples in the documentation) was accepted without error and produced a zip-code filter with no strategies. The singular name is still read, so existing policies keep working, but the plural is now the canonical name and is what Phileas writes when it serializes a policy. (issue #337)
 * The bitcoin-address filter now detects bech32 addresses (`bc1...`), which have been the default address format in most wallets since 2017 and were previously missed entirely. Both the 42-character version 0 form and the longer version 1 (taproot) form are detected, in lowercase or uppercase. The data part is restricted to the bech32 character set, which omits `1`, `b`, `i`, and `o`, so a string containing one of those is not matched. Base58 detection (`1...`, `3...`) is unchanged. (issue #338)
+* A policy can carry an optional top-level `metadata` object describing the policy itself, such as a `description` of what it does. It is held as raw JSON and round-tripped unchanged through a load and save, including keys Phileas does not model, so a description travels with the policy instead of living in separate storage. Nothing in `metadata` is read during filtering. This uses redaction policy schema 1.3.0. See the documentation for details. (PhiSQL philterd/phisql#23)
 * Using PhiSQL 1.4.0.
 
 ## Version 4.2.0 - June 24, 2026

--- a/docs/docs/evaluating-performance.md
+++ b/docs/docs/evaluating-performance.md
@@ -39,7 +39,6 @@ Now open `/opt/Phileas/policies/evaluation.json` in a text editor. (The content 
 
 ```
 {
-   "name": "default",
    "identifiers": {
       "emailAddress": {
          "emailAddressFilterStrategies": [
@@ -61,7 +60,7 @@ Now open `/opt/Phileas/policies/evaluation.json` in a text editor. (The content 
 }
 ```
 
-The first thing we need to do is to set the name of the policy. Replace `default` with `evaluation` and save the file.
+A policy is identified by its file name, which is already `evaluation.json` after the copy above.
 
 #### Identifying the Filters You Need
 
@@ -79,7 +78,7 @@ From the [bitcoin address filter documentation](filter_policies/filters/common_f
 
 ```
       "bitcoinAddress": {
-         "bitcoinAddressFilterStrategies": [
+         "bitcoinFilterStrategies": [
             {
                "strategy": "REDACT",
                "redactionFormat": "{{{REDACTED-%t}}}"
@@ -92,10 +91,9 @@ We can copy this configuration and paste it into our policy:
 
 ```
 {
-   "name": "evaluation",
    "identifiers": {
       "bitcoinAddress": {
-         "bitcoinAddressFilterStrategies": [
+         "bitcoinFilterStrategies": [
             {
                "strategy": "REDACT",
                "redactionFormat": "{{{REDACTED-%t}}}"

--- a/docs/docs/filter_policies/filter_policies.md
+++ b/docs/docs/filter_policies/filter_policies.md
@@ -21,6 +21,7 @@ A policy:
       tells Phileas how to manipulate that type of sensitive information when it is identified.
 * Can have an optional list of [terms](ignoring_sensitive_information.md) or [patterns](ignoring_sensitive_information.md).
 * Can have encryption keys to support [encryption](filter_strategies.md#fpe) of sensitive information.
+* Can have an optional [`metadata`](#policy-metadata) object describing the policy itself.
 
 ### An Example Policy
 
@@ -60,6 +61,38 @@ fits your use-case. See [Filter Strategies](filter_strategies.md) for all replac
 The name of the policy is `email-and-phone-numbers`. Policies can be named anything you like but their names must be
 unique from all other policies. As a best practice, the policy should be saved as `[name].json`, e.g.
 `email-and-phone-numbers.json`.
+
+### Policy Metadata
+
+A policy can carry an optional top-level `metadata` object describing the policy itself. Nothing in `metadata` affects
+detection or redaction. Phileas reads and writes it unchanged, so a description travels with the policy through export,
+import, and sharing instead of living in separate storage.
+
+```
+{
+   "metadata": {
+      "description": "Redacts intake forms before archival.",
+      "author": "records team"
+   },
+   "identifiers": {
+      "emailAddress": {
+         "emailAddressFilterStrategies": [
+            {
+               "strategy": "REDACT"
+            }
+         ]
+      }
+   }
+}
+```
+
+`metadata.description` is a human-readable description of what the policy does. It is available from
+`Policy.getDescription()` and set with `Policy.setDescription(String)`. Compiling a
+[PhiSQL](https://philterd.github.io/phisql/) policy with a `DESCRIPTION` clause writes the text here.
+
+Additional properties are allowed, as shown by `author` above, so the object can grow without a schema change. Keys
+Phileas does not model survive a load and save unchanged. Do not put sensitive information in `metadata`: it is not
+redacted, and it is written back out with the policy.
 
 ### Applying a Policy to Text
 

--- a/docs/docs/filter_policies/filter_policies.md
+++ b/docs/docs/filter_policies/filter_policies.md
@@ -3,11 +3,9 @@
 The types of sensitive information identified by Phileas and how that information is de-identified are controlled
 through policies.
 
-Each policy has a `name` that is used by Phileas to apply the appropriate de-identification methods. The `name` is
-passed to Phileas along with the text to be filtered. This
-provides flexibility and allows you to de-identify different types of documents in differing manners with a single
-instance of Phileas. For example, you may have a policy for bankruptcy documents and a separate policy for financial
-documents.
+A policy is passed to Phileas along with the text to be filtered. This provides flexibility and allows you to
+de-identify different types of documents in differing manners with a single instance of Phileas. For example, you may
+have a policy for bankruptcy documents and a separate policy for financial documents.
 
 > There are [sample policies](sample_filter_policies.md) available for immediate use or customization to fit your
 > use-cases.
@@ -31,7 +29,6 @@ when found. This policy identifies email addresses and phone numbers and redacts
 
 ```
 {
-   "name": "email-and-phone-numbers",
    "identifiers": {
       "emailAddress": {
          "emailAddressFilterStrategies": [
@@ -58,9 +55,9 @@ When an email address is identified by this policy, the email address is replace
 it is replaced with the text `{{{REDACTED-phone-number}}}`. You are free to change the redaction formats to whatever
 fits your use-case. See [Filter Strategies](filter_strategies.md) for all replacement options.
 
-The name of the policy is `email-and-phone-numbers`. Policies can be named anything you like but their names must be
-unique from all other policies. As a best practice, the policy should be saved as `[name].json`, e.g.
-`email-and-phone-numbers.json`.
+A policy is not named inside the JSON. A policy stored as a file is identified by its file name, so name the file for
+what the policy does, for example `email-and-phone-numbers.json`. To describe a policy in the policy itself, use
+[`metadata.description`](#policy-metadata).
 
 ### Policy Metadata
 

--- a/docs/docs/filter_policies/filter_strategies.md
+++ b/docs/docs/filter_policies/filter_strategies.md
@@ -11,7 +11,6 @@ A sample policy containing a filter strategy is shown below. In this example, em
 
 ```
 {
-   "name": "email-address",
    "identifiers": {
       "emailAddress": {
          "emailAddressFilterStrategies": [
@@ -83,7 +82,6 @@ An example filter using the `REDACT` filter strategy:
 
 ```
 {
-   "name": "email-address",
    "identifiers": {
       "emailAddress": {
          "emailAddressFilterStrategies": [
@@ -103,7 +101,6 @@ The `CRYPTO_REPLACE` filter strategy replaces each identified piece of sensitive
 
 ```
 {
-   "name":"sample-profile",
    "crypto": {
      "key": "...."
    },
@@ -141,7 +138,6 @@ An example policy using the `CRYPTO_REPLACE` filter strategy:
 
 ```
 {
-   "name": "email-address",
    "crypto": {
      "key": "...."
    },
@@ -165,7 +161,6 @@ An example policy using the `HASH_SHA256_REPLACE` filter strategy:
 
 ```
 {
-   "name": "email-address",
    "identifiers": {
       "emailAddress": {
          "emailAddressFilterStrategies": [
@@ -195,14 +190,15 @@ An example policy using the FPE\_ENCRYPT\_REPLACE filter strategy:
 
 ```
 {
-   "name": "credit-cards",
+   "fpe": {
+      "key": "...",
+      "tweak": "..."
+   },
    "identifiers": {
-      "creditCardNumbers": {
-         "creditCardNumbersFilterStrategies": [
+      "creditCard": {
+         "creditCardFilterStrategies": [
             {
-               "strategy": "FPE_ENCRYPT_REPLACE",
-               "key": "...",
-               "tweak": "..."
+               "strategy": "FPE_ENCRYPT_REPLACE"
             }
          ]
       }
@@ -224,7 +220,6 @@ An example policy using the `REALISTIC` filter strategy:
 
 ```
 {
-   "name": "email-address",
    "identifiers": {
       "emailAddress": {
          "emailAddressFilterStrategies": [
@@ -242,7 +237,6 @@ An example policy using the `RANDOM_REPLACE` filter strategy with a list of cand
 
 ```
 {
-   "name": "email-address",
    "identifiers": {
       "emailAddress": {
          "emailAddressFilterStrategies": [
@@ -265,7 +259,6 @@ An example policy using the `RANDOM_REPLACE` filter strategy with a UUID:
 
 ```
 {
-   "name": "email-address",
    "identifiers": {
       "emailAddress": {
          "emailAddressFilterStrategies": [
@@ -287,7 +280,6 @@ An example policy using the `STATIC_REPLACE` filter strategy:
 
 ```
 {
-   "name": "email-address",
    "identifiers": {
       "emailAddress": {
          "emailAddressFilterStrategies": [
@@ -309,19 +301,21 @@ An example policy using the `MAP_REPLACE` filter strategy:
 
 ```
 {
-   "name": "identifier",
    "identifiers": {
-      "identifier": {
-         "identifierFilterStrategies": [
-            {
-               "strategy": "MAP_REPLACE",
-               "mappings": { "Acme Corp": "Widget Co" },
-               "mappingFiles": [ "/etc/philter/vendors.tsv" ],
-               "caseSensitive": false,
-               "fallbackStrategy": "REDACT"
-            }
-         ]
-      }
+      "identifiers": [
+         {
+            "pattern": "Acme Corp|Globex",
+            "identifierFilterStrategies": [
+               {
+                  "strategy": "MAP_REPLACE",
+                  "mappings": { "Acme Corp": "Widget Co" },
+                  "mappingFiles": [ "/etc/philter/vendors.tsv" ],
+                  "caseSensitive": false,
+                  "fallbackStrategy": "REDACT"
+               }
+            ]
+         }
+      ]
    }
 }
 ```
@@ -337,10 +331,9 @@ An example policy using the `MASK` filter strategy:
 
 ```
 {
-   "name": "credit-cards",
    "identifiers": {
-      "creditCardNumbers": {
-         "creditCardNumbersFilterStrategies": [
+      "creditCard": {
+         "creditCardFilterStrategies": [
             {
                "strategy": "MASK",
                "maskCharacter": "#",
@@ -366,7 +359,6 @@ to 5 digits long. For example, `truncateLeaveCharacters=2` and a token of `90210
 
 ```
 {
-   "name": "zip-codes",
    "identifiers": {
       "zipCode": {
          "zipCodeFilterStrategies": [
@@ -388,9 +380,8 @@ The `ZERO_LEADING` filter strategy is only available to zip code filters. An exa
 
 ```
 {
-   "name": "zip-codes",
    "identifiers": {
-      "zipCodes": {
+      "zipCode": {
          "zipCodeFilterStrategies": [
             {
                "strategy": "ZERO_LEADING"
@@ -409,15 +400,16 @@ An example person's names filter using the `ABBREVIATE` filter strategy:
 
 ```
 {
-   "name": "ner-example",
    "identifiers": {
-      "pheye": {
-         "pheyeFilterStrategies": [
-            {
-               "strategy": "ABBREVIATE"
-            }
-         ]
-      }
+      "pheyes": [
+         {
+            "phEyeFilterStrategies": [
+               {
+                  "strategy": "ABBREVIATE"
+               }
+            ]
+         }
+      ]
    }
 }
 ```
@@ -430,7 +422,6 @@ The following is an example policy for credit cards that contains a condition to
 
 ```
 {
-  "name": "default",
   "identifiers": {
     "creditCard": {
       "creditCardFilterStrategies": [

--- a/docs/docs/filter_policies/filters/common_filters/ages.md
+++ b/docs/docs/filter_policies/filters/common_filters/ages.md
@@ -58,7 +58,6 @@ See [Conditions](#conditions) for details.
 
 ```
 {
-   "name": "ages-example",
    "identifiers": {
       "age": {
          "ageFilterStrategies": [

--- a/docs/docs/filter_policies/filters/common_filters/bank-routing-numbers.md
+++ b/docs/docs/filter_policies/filters/common_filters/bank-routing-numbers.md
@@ -52,7 +52,6 @@ See [Conditions](#conditions) for details.
 
 ```
 {
-   "name": "bank-routing-number-example",
    "identifiers": {
       "bankRoutingNumber": {
          "bankRoutingNumberFilterStrategies": [

--- a/docs/docs/filter_policies/filters/common_filters/bitcoin-addresses.md
+++ b/docs/docs/filter_policies/filters/common_filters/bitcoin-addresses.md
@@ -50,10 +50,9 @@ Each filter strategy may have one condition. See [Conditions](#conditions) for d
 
 ```
 {
-   "name": "bitcoin-address-example",
    "identifiers": {
       "bitcoinAddress": {
-         "bitcoinAddressFilterStrategies": [
+         "bitcoinFilterStrategies": [
             {
                "strategy": "REDACT",
                "redactionFormat": "{{{REDACTED-%t}}}"

--- a/docs/docs/filter_policies/filters/common_filters/creditcards.md
+++ b/docs/docs/filter_policies/filters/common_filters/creditcards.md
@@ -53,9 +53,8 @@ Each filter strategy may have one condition. See [Conditions](#conditions) for d
 
 ```
 {
-   "name": "credit-cards-example",
    "identifiers": {
-      "creditcard": {
+      "creditCard": {
          "onlyValidCreditCardNumbers": false,
          "onlyWordBoundaries": false,
          "creditCardFilterStrategies": [

--- a/docs/docs/filter_policies/filters/common_filters/currency.md
+++ b/docs/docs/filter_policies/filters/common_filters/currency.md
@@ -50,7 +50,6 @@ Each filter strategy may have one condition. See [Conditions](#conditions) for d
 
 ```
 {
-   "name": "currency-example",
    "identifiers": {
       "currency": {
          "currencyFilterStrategies": [

--- a/docs/docs/filter_policies/filters/common_filters/dates.md
+++ b/docs/docs/filter_policies/filters/common_filters/dates.md
@@ -85,7 +85,6 @@ The following policy redacts dates.
 
 ```
 {
-   "name": "dates-example",
    "identifiers": {
       "date": {
          "onlyValidDates": false,
@@ -106,7 +105,6 @@ The following policy to shift dates forward by 2 days and 4 months.
 
 ```
 {
-   "name": "dates-example",
    "identifiers": {
       "date": {
          "onlyValidDates": false,

--- a/docs/docs/filter_policies/filters/common_filters/drivers-license-numbers.md
+++ b/docs/docs/filter_policies/filters/common_filters/drivers-license-numbers.md
@@ -51,7 +51,6 @@ Each filter strategy may have one condition. See [Conditions](#conditions) for d
 
 ```
 {
-   "name": "drivers-license-example",
    "identifiers": {
       "driversLicense": {
          "driversLicenseFilterStrategies": [

--- a/docs/docs/filter_policies/filters/common_filters/ein.md
+++ b/docs/docs/filter_policies/filters/common_filters/ein.md
@@ -53,7 +53,6 @@ Each filter strategy may have one condition. See [Conditions](#conditions) for d
 
 ```
 {
-   "name": "ein-example",
    "identifiers": {
       "ein": {
          "onlyValidPrefixes": true,

--- a/docs/docs/filter_policies/filters/common_filters/email-addresses.md
+++ b/docs/docs/filter_policies/filters/common_filters/email-addresses.md
@@ -52,7 +52,6 @@ Each filter strategy may have one condition. See [Conditions](#conditions) for d
 
 ```
 {
-   "name": "email-address-example",
    "identifiers": {
       "emailAddress": {
          "emailAddressFilterStrategies": [

--- a/docs/docs/filter_policies/filters/common_filters/iban-codes.md
+++ b/docs/docs/filter_policies/filters/common_filters/iban-codes.md
@@ -53,7 +53,6 @@ Each filter strategy may have one condition. See [Conditions](#conditions) for d
 
 ```
 {
-   "name": "iban-example",
    "identifiers": {
       "ibanCode": {
          "onlyValidIBANCodes": false,

--- a/docs/docs/filter_policies/filters/common_filters/ip-addresses.md
+++ b/docs/docs/filter_policies/filters/common_filters/ip-addresses.md
@@ -51,7 +51,6 @@ Each filter strategy may have one condition. See [Conditions](#conditions) for d
 
 ```
 {
-   "name": "ip-address-example",
    "identifiers": {
       "ipAddress": {
          "ipAddressFilterStrategies": [

--- a/docs/docs/filter_policies/filters/common_filters/mac-addresses.md
+++ b/docs/docs/filter_policies/filters/common_filters/mac-addresses.md
@@ -50,7 +50,6 @@ Each filter strategy may have one condition. See [Conditions](#conditions) for d
 
 ```
 {
-   "name": "mac-address-example",
    "identifiers": {
       "macAddress": {
          "macAddressFilterStrategies": [

--- a/docs/docs/filter_policies/filters/common_filters/passport-numbers.md
+++ b/docs/docs/filter_policies/filters/common_filters/passport-numbers.md
@@ -50,7 +50,6 @@ Each filter strategy may have one condition. See [Conditions](#conditions) for d
 
 ```
 {
-   "name": "passport-number-example",
    "identifiers": {
       "passportNumber": {
          "passportNumberFilterStrategies": [

--- a/docs/docs/filter_policies/filters/common_filters/phone-number-extensions.md
+++ b/docs/docs/filter_policies/filters/common_filters/phone-number-extensions.md
@@ -50,7 +50,6 @@ Each filter strategy may have one condition. See [Conditions](#conditions) for d
 
 ```
 {
-   "name": "phone-number-ext-example",
    "identifiers": {
       "phoneNumberExtension": {
          "phoneNumberExtensionFilterStrategies": [

--- a/docs/docs/filter_policies/filters/common_filters/phone-numbers.md
+++ b/docs/docs/filter_policies/filters/common_filters/phone-numbers.md
@@ -51,7 +51,6 @@ Each filter strategy may have one condition. See [Conditions](#conditions) for d
 
 ```
 {
-   "name": "phone-number-example",
    "identifiers": {
       "phoneNumber": {
          "phoneNumberFilterStrategies": [
@@ -69,7 +68,6 @@ To detect national-format numbers from regions other than the United States, set
 
 ```
 {
-   "name": "phone-number-example",
    "identifiers": {
       "phoneNumber": {
          "region": ["US", "GB", "FR"],

--- a/docs/docs/filter_policies/filters/common_filters/sections.md
+++ b/docs/docs/filter_policies/filters/common_filters/sections.md
@@ -60,17 +60,19 @@ Each filter strategy may have one condition. See [Conditions](#conditions) for d
 
 ```
 {
-   "name": "sections-example",
    "identifiers": {
-      "section": {
-         "startPattern": "START",
-         "endPattern": "END",
-         "sectionFilterStrategies": [
-            {
-               "strategy": "REDACT",
-               "redactionFormat": "{{{REDACTED-%t}}}"
-            }
-         ]
-      }
+      "sections": [
+         {
+            "startPattern": "START",
+            "endPattern": "END",
+            "sectionFilterStrategies": [
+               {
+                  "strategy": "REDACT",
+                  "redactionFormat": "{{{REDACTED-%t}}}"
+               }
+            ]
+         }
+      ]
+   }
 }
 ```

--- a/docs/docs/filter_policies/filters/common_filters/ssns-and-tins.md
+++ b/docs/docs/filter_policies/filters/common_filters/ssns-and-tins.md
@@ -50,7 +50,6 @@ Each filter strategy may have one condition. See [Conditions](#conditions) for d
 
 ```
 {
-   "name": "ssn-tin-example",
    "identifiers": {
       "ssn": {
          "ssnFilterStrategies": [

--- a/docs/docs/filter_policies/filters/common_filters/street-address.md
+++ b/docs/docs/filter_policies/filters/common_filters/street-address.md
@@ -50,7 +50,6 @@ Each filter strategy may have one condition. See [Conditions](#conditions) for d
 
 ```
 {
-   "name": "street-address-example",
    "identifiers": {
       "streetAddress": {
          "streetAddressFilterStrategies": [

--- a/docs/docs/filter_policies/filters/common_filters/tracking-numbers.md
+++ b/docs/docs/filter_policies/filters/common_filters/tracking-numbers.md
@@ -52,7 +52,6 @@ Each filter strategy may have one condition. See [Conditions](#conditions) for d
 
 ```
 {
-   "name": "tracking-numbers-example",
    "identifiers": {
       "trackingNumber": {
          "trackingNumberFilterStrategies": [

--- a/docs/docs/filter_policies/filters/common_filters/urls.md
+++ b/docs/docs/filter_policies/filters/common_filters/urls.md
@@ -66,7 +66,6 @@ Each filter strategy may have one condition. See [Conditions](#conditions) for d
 
 ```
 {
-   "name": "urls-example",
    "identifiers": {
       "url": {
          "requireHttpWwwPrefix": true,

--- a/docs/docs/filter_policies/filters/common_filters/vins.md
+++ b/docs/docs/filter_policies/filters/common_filters/vins.md
@@ -51,7 +51,6 @@ Each filter strategy may have one condition. See [Conditions](#conditions) for d
 
 ```
 {
-   "name": "vins-example",
    "identifiers": {
       "vin": {
          "vinFilterStrategies": [

--- a/docs/docs/filter_policies/filters/common_filters/zip-codes.md
+++ b/docs/docs/filter_policies/filters/common_filters/zip-codes.md
@@ -64,7 +64,6 @@ the `POPULATION` conditional with this in mind.
 
 ```
 {
-   "name": "zip-code-example",
    "identifiers": {
       "zipCode": {
          "zipCodeFilterStrategies": [

--- a/docs/docs/filter_policies/filters/custom_filters/dictionary.md
+++ b/docs/docs/filter_policies/filters/custom_filters/dictionary.md
@@ -57,15 +57,14 @@ Each filter strategy may have one condition. See [Conditions](#conditions) for d
 
 ```
 {
-   "name": "dictionary-example",
    "identifiers": {
       "dictionaries": [
-         "customDictionary": {
+         {
             "terms": ["john", "jane", "doe"],
-            "files": "c:\temp\dictionary.txt",
+            "files": ["/tmp/dictionary.txt"],
             "fuzzy": true,
             "sensitivity": "medium",
-            "sectionFilterStrategies": [
+            "customFilterStrategies": [
                {
                   "strategy": "REDACT",
                   "redactionFormat": "{{{REDACTED-%t}}}"

--- a/docs/docs/filter_policies/filters/custom_filters/identifier.md
+++ b/docs/docs/filter_policies/filters/custom_filters/identifier.md
@@ -111,7 +111,6 @@ Each filter strategy may have one condition. See [Conditions](#conditions) for d
 
 ```
 {
-  "name": "default",
   "identifiers": {
     "identifiers": [
       {
@@ -138,7 +137,6 @@ matches that pass the Luhn checksum.
 
 ```
 {
-  "name": "default",
   "identifiers": {
     "identifiers": [
       {

--- a/docs/docs/filter_policies/filters/locations/cities.md
+++ b/docs/docs/filter_policies/filters/locations/cities.md
@@ -52,7 +52,6 @@ Each filter strategy may have one condition. See [Conditions](#conditions) for d
 
 ```
 {
-   "name": "cities-example",
    "identifiers": {
       "city": {
          "sensitivity": "medium",

--- a/docs/docs/filter_policies/filters/locations/counties.md
+++ b/docs/docs/filter_policies/filters/locations/counties.md
@@ -52,7 +52,6 @@ Each filter strategy may have one condition. See [Conditions](#conditions) for d
 
 ```
 {
-   "name": "counties-example",
    "identifiers": {
       "county": {
          "sensitivity": "medium",

--- a/docs/docs/filter_policies/filters/locations/hospitals.md
+++ b/docs/docs/filter_policies/filters/locations/hospitals.md
@@ -52,7 +52,6 @@ Each filter strategy may have one condition. See [Conditions](#conditions) for d
 
 ```
 {
-   "name": "hospitals-example",
    "identifiers": {
       "hospital": {
          "sensitivity": "medium",

--- a/docs/docs/filter_policies/filters/locations/state-abbreviations.md
+++ b/docs/docs/filter_policies/filters/locations/state-abbreviations.md
@@ -51,7 +51,6 @@ Each filter strategy may have one condition. See [Conditions](#conditions) for d
 
 ```
 {
-   "name": "states-abbreviations-example",
    "identifiers": {
       "stateAbbreviation": {
          "stateAbbreviationFilterStrategies": [

--- a/docs/docs/filter_policies/filters/locations/states.md
+++ b/docs/docs/filter_policies/filters/locations/states.md
@@ -53,7 +53,6 @@ Each filter strategy may have one condition. See [Conditions](#conditions) for d
 
 ```
 {
-   "name": "states-example",
    "identifiers": {
       "state": {
          "stateFilterStrategies": [

--- a/docs/docs/filter_policies/filters/persons_names/first-names.md
+++ b/docs/docs/filter_policies/filters/persons_names/first-names.md
@@ -55,7 +55,6 @@ Each filter strategy may have one condition. See [Conditions](#conditions) for d
 
 ```
 {
-   "name": "first-names-example",
    "identifiers": {
       "firstName": {
          "firstNameFilterStrategies": [

--- a/docs/docs/filter_policies/filters/persons_names/ph-eye.md
+++ b/docs/docs/filter_policies/filters/persons_names/ph-eye.md
@@ -60,19 +60,20 @@ Each filter strategy may have one condition. See [Conditions](#conditions) for d
 
 ```
 {
-   "name": "ner-example",
    "identifiers": {
-      "pheye": {
-        "phEyeConfiguration": {
-            "endpoint": "http://localhost:18080"
-        },
-        "pheyeFilterStrategies": [
-           {
-              "strategy": "REDACT",
-              "redactionFormat": "{{{REDACTED-%t}}}"
-           }
-        ]
-      }
+      "pheyes": [
+        {
+          "phEyeConfiguration": {
+              "endpoint": "http://localhost:18080"
+          },
+          "phEyeFilterStrategies": [
+             {
+                "strategy": "REDACT",
+                "redactionFormat": "{{{REDACTED-%t}}}"
+             }
+          ]
+        }
+      ]
    }
 }
 ```
@@ -96,19 +97,20 @@ is processed.
 
 ```
 {
-   "name": "ner-local-example",
    "identifiers": {
-      "pheye": {
-        "phEyeConfiguration": {
-            "modelPath": "/models/ph-eye-pii-en-small"
-        },
-        "pheyeFilterStrategies": [
-           {
-              "strategy": "REDACT",
-              "redactionFormat": "{{{REDACTED-%t}}}"
-           }
-        ]
-      }
+      "pheyes": [
+        {
+          "phEyeConfiguration": {
+              "modelPath": "/models/ph-eye-pii-en-small"
+          },
+          "phEyeFilterStrategies": [
+             {
+                "strategy": "REDACT",
+                "redactionFormat": "{{{REDACTED-%t}}}"
+             }
+          ]
+        }
+      ]
    }
 }
 ```

--- a/docs/docs/filter_policies/filters/persons_names/surnames.md
+++ b/docs/docs/filter_policies/filters/persons_names/surnames.md
@@ -55,7 +55,6 @@ Each filter strategy may have one condition. See [Conditions](#conditions) for d
 
 ```
 {
-   "name": "surnames-example",
    "identifiers": {
       "surname": {
          "surnameFilterStrategies": [

--- a/docs/docs/filter_policies/ignoring_sensitive_information.md
+++ b/docs/docs/filter_policies/ignoring_sensitive_information.md
@@ -15,7 +15,6 @@ In the policy shown below, an ignore list is set at the level of the policy. The
 
 ```
 {
-   "name": "example-policy",
    "ignored": [
      {
        "name": "names to ignore",
@@ -40,12 +39,11 @@ Terms to be ignored at the policy level can also be read from one or more files 
 
 ```
 {
-   "name": "example-policy",
    "ignored": [
      {
        "name": "names to ignore",
        "terms": ["john smith", "jane doe"],
-       "files": ["/tmp/names.txt"]
+       "files": ["/tmp/names.txt"],
        "caseSensitive": false
      }
    ],   
@@ -68,7 +66,6 @@ In the policy shown below, an ignore list is set at the level of a filter. The t
 
 ```
 {
-   "name": "example-filter-profile",
    "identifiers": {
       "emailAddress": {
          "ignored": ["john smith", "jane doe"],
@@ -97,7 +94,6 @@ In the policy shown below, ignore patterns are set at the level of the policy. T
 
 ```
 {
-   "name": "example-policy",
    "ignoredPatterns": [
      {
        "name": "ignore-room-numbers",
@@ -123,7 +119,6 @@ In the policy shown below, ignore patterns are set at the level of a filter. The
 
 ```
 {
-   "name": "example-policy",
    "identifiers": {
       "emailAddress": {
          "ignoredPatterns": [

--- a/docs/docs/filter_policies/pdf.md
+++ b/docs/docs/filter_policies/pdf.md
@@ -22,7 +22,6 @@ The following is an example policy setting the PDF redaction options.
 
 ```
 {
-   "name": "example-pdf-policy",
    "identifiers": {
       "emailAddress": {
          "emailAddressFilterStrategies": [

--- a/docs/docs/filter_policies/sample_filter_policies.md
+++ b/docs/docs/filter_policies/sample_filter_policies.md
@@ -10,7 +10,6 @@ This policy finds email addresses and phone numbers and redacts them with `{{{RE
 
 ```
 {
-  "name": "email-and-phone-numbers",
   "identifiers": {
     "emailAddress": {
       "emailAddressFilterStrategies": [
@@ -34,20 +33,25 @@ This policy finds email addresses and phone numbers and redacts them with `{{{RE
 
 ### Persons Names and SSNs
 
-This policy finds persons names and SSNs and redacts them with `{{{REDACTED-entity}}}` and `{{{REDACTED-ssn}}}`, respectively.
+This policy finds persons names with [PhEye](filters/persons_names/ph-eye.md) and SSNs with the SSN filter, and
+redacts each with the type of the filter that found it. It needs a running PhEye service at the `endpoint` shown.
 
 ```
 {
-  "name": "persons-names-ssn",
   "identifiers": {
-    "ner": {
-      "nerFilterStrategies": [
-        {
-          "strategy": "REDACT",
-          "redactionFormat": "{{{REDACTED-%t}}}"
-        }
-      ]
-    },
+    "pheyes": [
+      {
+        "phEyeConfiguration": {
+          "endpoint": "http://localhost:18080"
+        },
+        "phEyeFilterStrategies": [
+          {
+            "strategy": "REDACT",
+            "redactionFormat": "{{{REDACTED-%t}}}"
+          }
+        ]
+      }
+    ],
     "ssn": {
       "ssnFilterStrategies": [
         {
@@ -66,7 +70,6 @@ This policy finds dates, URLs, and VINs. Dates and URLs are redacted with `{{{RE
 
 ```
 {
-  "name": "dates-urls-vin",
   "identifiers": {
     "date": {
       "dateFilterStrategies": [
@@ -101,7 +104,6 @@ This policy finds IP addresses and replaces each identified IP address with the 
 
 ```
 {
-  "name": "ip-addresses",
   "identifiers": {
     "ipAddress": {
       "ipAddressFilterStrategies": [
@@ -122,7 +124,6 @@ This policy finds ZIP codes starting with `90` and truncates the zip code to jus
 
 ```
 {
-  "name": "zip-codes",
   "identifiers": {
     "creditCard": {
       "creditCardFilterStrategies": [
@@ -143,7 +144,6 @@ This policy enables text splitting for input over 10,000 characters.
 
 ```
 {
-  "name": "default-split-enabled",
   "config": {
     "splitting": {
       "enabled": true,
@@ -170,7 +170,6 @@ This policy has a list of globally ignored terms.
 
 ```
 {
-  "name": "default-global-ignore",
   "ignored": [
     {
       "name": "ignored credit cards",

--- a/src/main/java/ai/philterd/phileas/policy/Policy.java
+++ b/src/main/java/ai/philterd/phileas/policy/Policy.java
@@ -19,6 +19,7 @@ import ai.philterd.phisql.CompileResult;
 import ai.philterd.phisql.Compiler;
 import ai.philterd.phisql.PhiSQL;
 import com.google.gson.Gson;
+import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import com.google.gson.annotations.Expose;
 import com.google.gson.annotations.SerializedName;
@@ -187,6 +188,55 @@ public class Policy {
 
     public void setMetadata(JsonObject metadata) {
         this.metadata = metadata;
+    }
+
+    /**
+     * Returns the policy's description, held in the metadata as {@code metadata.description} and
+     * written there by a PhiSQL {@code DESCRIPTION} clause.
+     * @return The description, or <code>null</code> when the policy has none.
+     */
+    public String getDescription() {
+
+        if (metadata == null || !metadata.has("description")) {
+            return null;
+        }
+
+        final JsonElement description = metadata.get("description");
+
+        // The schema defines description as a string. Anything else (an object, an array, a null) has
+        // no string form, so report it as absent rather than guessing at one.
+        return description.isJsonPrimitive() ? description.getAsString() : null;
+
+    }
+
+    /**
+     * Sets the policy's description, held in the metadata as {@code metadata.description}. Any other
+     * metadata keys are left in place.
+     * @param description The description. A <code>null</code> removes the description.
+     */
+    public void setDescription(final String description) {
+
+        if (description == null) {
+
+            if (metadata != null) {
+                metadata.remove("description");
+
+                // Drop the section entirely once it is empty so it is not serialized as "metadata": {}.
+                if (metadata.isEmpty()) {
+                    metadata = null;
+                }
+            }
+
+            return;
+
+        }
+
+        if (metadata == null) {
+            metadata = new JsonObject();
+        }
+
+        metadata.addProperty("description", description);
+
     }
 
     public Config getConfig() {

--- a/src/test/java/ai/philterd/phileas/policy/PolicyTest.java
+++ b/src/test/java/ai/philterd/phileas/policy/PolicyTest.java
@@ -124,6 +124,96 @@ public class PolicyTest {
     }
 
     @Test
+    public void descriptionReadsFromMetadata() {
+
+        final Policy policy = new Gson().fromJson("""
+                { "metadata": { "description": "Client intake forms." } }""", Policy.class);
+
+        Assertions.assertEquals("Client intake forms.", policy.getDescription());
+
+    }
+
+    @Test
+    public void descriptionIsNullWhenAbsent() {
+
+        final Gson gson = new Gson();
+
+        // No metadata at all, metadata without a description, and a description that is not a string.
+        Assertions.assertNull(gson.fromJson("{}", Policy.class).getDescription());
+        Assertions.assertNull(gson.fromJson("""
+                { "metadata": { "author": "records team" } }""", Policy.class).getDescription());
+        Assertions.assertNull(gson.fromJson("""
+                { "metadata": { "description": { "text": "no" } } }""", Policy.class).getDescription());
+
+    }
+
+    @Test
+    public void settingDescriptionKeepsOtherMetadataKeys() {
+
+        final Policy policy = new Gson().fromJson("""
+                { "metadata": { "description": "Old.", "author": "records team" } }""", Policy.class);
+
+        policy.setDescription("New.");
+
+        Assertions.assertEquals("New.", policy.getDescription());
+        Assertions.assertEquals("records team", policy.getMetadata().get("author").getAsString());
+
+    }
+
+    @Test
+    public void settingDescriptionOnPolicyWithoutMetadataCreatesTheSection() {
+
+        final Policy policy = new Gson().fromJson("{}", Policy.class);
+        policy.setDescription("Client intake forms.");
+
+        Assertions.assertEquals("Client intake forms.", policy.getDescription());
+        Assertions.assertEquals("Client intake forms.", policy.getMetadata().get("description").getAsString());
+
+    }
+
+    @Test
+    public void clearingTheOnlyDescriptionRemovesTheMetadataSection() {
+
+        final Policy policy = new Gson().fromJson("""
+                { "metadata": { "description": "Client intake forms." } }""", Policy.class);
+
+        policy.setDescription(null);
+
+        Assertions.assertNull(policy.getDescription());
+
+        // The section is dropped rather than left behind as "metadata": {}.
+        Assertions.assertNull(policy.getMetadata());
+        Assertions.assertFalse(new Gson().toJson(policy).contains("metadata"));
+
+    }
+
+    @Test
+    public void clearingDescriptionKeepsRemainingMetadata() {
+
+        final Policy policy = new Gson().fromJson("""
+                { "metadata": { "description": "Client intake forms.", "author": "records team" } }""", Policy.class);
+
+        policy.setDescription(null);
+
+        Assertions.assertNull(policy.getDescription());
+        Assertions.assertEquals("records team", policy.getMetadata().get("author").getAsString());
+
+    }
+
+    @Test
+    public void descriptionFromPhiSQLIsCarriedInMetadata() {
+
+        // PhiSQL 1.4.0 compiles a DESCRIPTION clause into metadata.description.
+        final Policy policy = Policy.fromPhiSQL("""
+                POLICY intake DESCRIPTION 'Client intake forms.';
+                REDACT SSN WITH REDACT;
+                """);
+
+        Assertions.assertEquals("Client intake forms.", policy.getDescription());
+
+    }
+
+    @Test
     public void zipCodeAcceptsBothStrategyKeys() {
 
         final String plural = """


### PR DESCRIPTION
### Description
Removes policy name from docs. Stacks on #378 so merge it first.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
